### PR TITLE
Localize profile descriptions in list-profiles output

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Runtime output language can be selected with a global option or environment vari
 
 ```bash
 ./swiftnest --lang ko --help
-SWIFTNEST_LANG=ko ./swiftnest workflow list
+SWIFTNEST_LANG=ko ./swiftnest list-profiles
 ```
 
 ## Publish Your Own Copy

--- a/README_kr.md
+++ b/README_kr.md
@@ -372,7 +372,7 @@ make upgrade PROFILE=advanced
 
 ```bash
 ./swiftnest --lang ko --help
-SWIFTNEST_LANG=ko ./swiftnest workflow list
+SWIFTNEST_LANG=ko ./swiftnest list-profiles
 ```
 
 ## 자신의 사본 공개하기

--- a/profiles/advanced.yaml
+++ b/profiles/advanced.yaml
@@ -1,5 +1,6 @@
 name: advanced
 description: Strict setup for complex apps and long-lived codebases.
+description_ko: 복잡한 앱과 장기 운영 코드베이스에 맞춘 엄격한 구성입니다.
 default_skills:
   - ios-architecture
   - swiftui-rules

--- a/profiles/basic.yaml
+++ b/profiles/basic.yaml
@@ -1,5 +1,6 @@
 name: basic
 description: Minimal setup for solo projects and MVPs.
+description_ko: 개인 프로젝트와 MVP에 맞춘 최소 구성입니다.
 default_skills:
   - ios-architecture
   - swiftui-rules

--- a/profiles/intermediate.yaml
+++ b/profiles/intermediate.yaml
@@ -1,5 +1,6 @@
 name: intermediate
 description: Balanced setup for product development.
+description_ko: 제품 개발에 균형 있게 맞춘 구성입니다.
 default_skills:
   - ios-architecture
   - swiftui-rules

--- a/tools/swiftnest-cli/Sources/SwiftNestCLI.swift
+++ b/tools/swiftnest-cli/Sources/SwiftNestCLI.swift
@@ -461,10 +461,35 @@ enum SwiftNestCLI {
     }
 
     static func runListProfiles(repository: SwiftNestRepository) throws {
-        for profileURL in try repository.availableProfiles() {
+        for summary in try listProfileSummaries(repository: repository) {
+            print(summary)
+        }
+    }
+
+    static func listProfileSummaries(
+        repository: SwiftNestRepository,
+        language: SwiftNestLanguage = SwiftNestLocalizer.activeLanguage
+    ) throws -> [String] {
+        try repository.availableProfiles().map { profileURL in
             let data = try HarnessDocumentLoader.loadObject(at: profileURL)
-            let description = HarnessDocumentLoader.string(data, key: "description", default: "")
-            print("\(profileURL.deletingPathExtension().lastPathComponent): \(description)")
+            let description = localizedProfileDescription(from: data, language: language)
+            return "\(profileURL.deletingPathExtension().lastPathComponent): \(description)"
+        }
+    }
+
+    static func localizedProfileDescription(
+        from values: [String: Any],
+        language: SwiftNestLanguage = SwiftNestLocalizer.activeLanguage
+    ) -> String {
+        switch language {
+        case .ko:
+            let koreanDescription = HarnessDocumentLoader.string(values, key: "description_ko", default: "")
+            if !koreanDescription.isEmpty {
+                return koreanDescription
+            }
+            return HarnessDocumentLoader.string(values, key: "description", default: "")
+        case .en:
+            return HarnessDocumentLoader.string(values, key: "description", default: "")
         }
     }
 

--- a/tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift
+++ b/tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift
@@ -106,6 +106,47 @@ final class SwiftNestCLITests: XCTestCase {
         )
     }
 
+    func testListProfileSummariesUseEnglishDescriptionsByDefault() throws {
+        let summaries = try SwiftNestCLI.listProfileSummaries(
+            repository: SwiftNestRepository(rootURL: try makeRepositoryFixture()),
+            language: .en
+        )
+
+        XCTAssertEqual(
+            summaries,
+            [
+                "advanced: Strict setup for complex apps and long-lived codebases.",
+                "basic: Minimal setup for solo projects and MVPs.",
+                "intermediate: Balanced setup for product development.",
+            ]
+        )
+    }
+
+    func testListProfileSummariesUseKoreanDescriptionsWhenAvailable() throws {
+        let summaries = try SwiftNestCLI.listProfileSummaries(
+            repository: SwiftNestRepository(rootURL: try makeRepositoryFixture()),
+            language: .ko
+        )
+
+        XCTAssertEqual(
+            summaries,
+            [
+                "advanced: 복잡한 앱과 장기 운영 코드베이스에 맞춘 엄격한 구성입니다.",
+                "basic: 개인 프로젝트와 MVP에 맞춘 최소 구성입니다.",
+                "intermediate: 제품 개발에 균형 있게 맞춘 구성입니다.",
+            ]
+        )
+    }
+
+    func testLocalizedProfileDescriptionFallsBackToEnglishWhenKoreanValueMissing() {
+        let values: [String: Any] = ["description": "English only"]
+
+        XCTAssertEqual(
+            SwiftNestCLI.localizedProfileDescription(from: values, language: .ko),
+            "English only"
+        )
+    }
+
     func testRootWrapperUsesKoreanErrorWhenSwiftIsMissing() throws {
         let wrapperURL = repositoryRootURL().appendingPathComponent("swiftnest")
         let emptyBinDirectory = FileManager.default.temporaryDirectory
@@ -179,10 +220,35 @@ final class SwiftNestCLITests: XCTestCase {
             "tools/swiftnest-cli/Sources/main.swift",
             "tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift",
         ]
+        let fileContents: [String: String] = [
+            "profiles/advanced.yaml": """
+            name: advanced
+            description: Strict setup for complex apps and long-lived codebases.
+            description_ko: 복잡한 앱과 장기 운영 코드베이스에 맞춘 엄격한 구성입니다.
+            default_skills:
+              - ios-architecture
+            """,
+            "profiles/basic.yaml": """
+            name: basic
+            description: Minimal setup for solo projects and MVPs.
+            description_ko: 개인 프로젝트와 MVP에 맞춘 최소 구성입니다.
+            default_skills:
+              - ios-architecture
+            """,
+            "profiles/intermediate.yaml": """
+            name: intermediate
+            description: Balanced setup for product development.
+            description_ko: 제품 개발에 균형 있게 맞춘 구성입니다.
+            default_skills:
+              - ios-architecture
+            """,
+        ]
+
         for filePath in filePaths {
             let destinationURL = root.appendingPathComponent(filePath)
             try fileManager.createDirectory(at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try "fixture".write(to: destinationURL, atomically: true, encoding: .utf8)
+            let contents = fileContents[filePath] ?? "fixture"
+            try contents.write(to: destinationURL, atomically: true, encoding: .utf8)
         }
 
         return root


### PR DESCRIPTION
## Summary
- add Korean profile descriptions to the profile YAML metadata
- localize `list-profiles` output using the active runtime language with English fallback
- update regression tests and README examples for localized profile listing

## Testing
- swift test --package-path tools/swiftnest-cli
- ./swiftnest --lang ko list-profiles
- ./swiftnest --lang en list-profiles
- git diff --check

Closes #4