### PR TITLE
Add guided onboard command for SwiftNest setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ When a feature affects starter contents or Homebrew-visible behavior, finish the
 3. Download the matching GitHub tag archive and compute its SHA256.
 4. Render `packaging/homebrew/swiftnest.rb.template` into the tap repository as `Formula/swiftnest.rb`.
 5. Commit and push the updated formula in `oozoofrog/homebrew-swiftnest` (or the active tap repo).
-6. Verify with `brew install swiftnest`, `brew test swiftnest`, and at least one smoke test such as `swiftnest install --target <repo>` or `swiftnest --lang ko list-profiles`.
+6. Verify with `brew install swiftnest`, `brew test swiftnest`, and at least one smoke test such as `swiftnest onboard --target <repo>` or `swiftnest --lang ko list-profiles`.
 
 ## Completion Expectations
 - Summarize files changed.

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ list-skills:
 list-profiles:
 	$(SWIFTNEST) list-profiles
 
+onboard:
+	@if [ -n "$(TARGET)" ]; then \
+		$(SWIFTNEST) onboard --target "$(TARGET)" --config $(CONFIG); \
+	else \
+		$(SWIFTNEST) onboard --config $(CONFIG); \
+	fi
+
 init:
 	$(SWIFTNEST) init --config $(CONFIG)
 

--- a/README.md
+++ b/README.md
@@ -50,26 +50,21 @@ The `./swiftnest` shell entrypoint builds a local macOS Swift binary on first us
 If an agent only receives this GitHub link, the expected installation flow is:
 
 1. Clone or download this starter into a temporary directory.
-2. Run the shell entrypoint from the starter checkout into the target app repository.
-3. In the target repository, create `config/project.yaml`.
-4. Run `init` from the target repository so generated files land in the app repository, not in the starter checkout.
+2. Run the shell entrypoint from the starter checkout into the target app repository with `onboard`.
+3. Review the generated `config/project.yaml`, `AGENTS.md`, and `Docs/` output in the target repository.
+4. Start agent work from the target repository root.
 5. Commit the generated `Docs/` and `.ai-harness/` files in the target repository.
 
 Example:
 
 ```bash
 git clone https://github.com/oozoofrog/swift-nest.git /tmp/swift-nest
-/tmp/swift-nest/swiftnest install --target /path/to/current-ios-repo
-
-cd /path/to/current-ios-repo
-test -f config/project.yaml || cp config/project.example.yaml config/project.yaml
-./swiftnest init \
-  --config config/project.yaml \
-  --profile intermediate \
-  --skills ios-architecture,swiftui-rules,concurrency-rules,networking-rules,testing-rules
+/tmp/swift-nest/swiftnest onboard \
+  --target /path/to/current-ios-repo \
+  --non-interactive
 ```
 
-The first invocation builds a local Swift binary under `tools/swiftnest-cli/.build/`. Do not run `./swiftnest init` inside the starter checkout when the goal is to install SwiftNest into another repository.
+The first invocation builds a local Swift binary under `tools/swiftnest-cli/.build/`. Do not run `./swiftnest onboard` or `./swiftnest init` inside the starter checkout when the goal is to install SwiftNest into another repository.
 
 ## Homebrew Packaging
 
@@ -90,7 +85,7 @@ Once the tap is published, the intended install flow is:
 ```bash
 brew tap oozoofrog/swiftnest https://github.com/oozoofrog/homebrew-swiftnest
 brew install swiftnest
-swiftnest install --target /path/to/current-ios-repo
+swiftnest onboard --target /path/to/current-ios-repo
 ```
 
 The Homebrew-installed `swiftnest` command is bootstrap-oriented. When the current directory already contains a repo-local `./swiftnest`, the tap wrapper should delegate to that local entrypoint so follow-up commands continue to run against the repository copy.
@@ -101,34 +96,31 @@ The repo-local `./swiftnest` script still builds a local macOS Swift binary on f
 
 This section assumes the current repository already contains the SwiftNest-managed files and that the macOS Swift toolchain is available.
 
-### 1. Copy the example config
+### 1. Run onboarding
+
+```bash
+./swiftnest onboard
+```
+
+### 2. Or run onboarding non-interactively
+
+```bash
+./swiftnest onboard \
+  --config config/project.yaml \
+  --profile intermediate \
+  --skills ios-architecture,swiftui-rules,concurrency-rules,testing-rules,location-rules \
+  --workflows permissions,review \
+  --non-interactive
+```
+
+### 3. Use the lower-level commands when you need finer control
 
 ```bash
 cp config/project.example.yaml config/project.yaml
-```
-
-### 2. Edit the values
-
-Set the project-specific values in `config/project.yaml`.
-
-If you already know the preferred verification commands for the project, set optional `build_command` and `test_command` too.
-
-### 3. Run the initializer interactively
-
-```bash
 ./swiftnest init --config config/project.yaml
 ```
 
-### 4. Run the initializer non-interactively
-
-```bash
-./swiftnest init \
-  --config config/project.yaml \
-  --profile intermediate \
-  --skills ios-architecture,swiftui-rules,concurrency-rules,testing-rules,location-rules
-```
-
-### 5. Rerender or upgrade later
+### 4. Rerender or upgrade later
 
 ```bash
 ./swiftnest render-context
@@ -149,10 +141,10 @@ Recommended flow:
 
 1. Create the new repository or enter the empty repository root.
 2. Clone this starter to a temporary directory.
-3. Install the managed SwiftNest files into the new repository.
-4. Create `config/project.yaml` and fill in the intended app context.
-5. Start with a light profile and a small skill set.
-6. Run `init` and commit the generated `Docs/` and `.ai-harness/`.
+3. Run `onboard` into the new repository so SwiftNest installs, creates config, and initializes docs in one flow.
+4. Review `config/project.yaml` and the generated `AGENTS.md`.
+5. Start with a light profile and a small skill set if you need to rerun onboarding with explicit options.
+6. Commit the generated `Docs/` and `.ai-harness/`.
 
 Example:
 
@@ -162,13 +154,7 @@ cd MyNewApp
 git init
 
 git clone https://github.com/oozoofrog/swift-nest.git /tmp/swift-nest
-/tmp/swift-nest/swiftnest install --target "$PWD"
-
-cp config/project.example.yaml config/project.yaml
-./swiftnest init \
-  --config config/project.yaml \
-  --profile basic \
-  --skills ios-architecture,swiftui-rules,testing-rules
+/tmp/swift-nest/swiftnest onboard --target "$PWD"
 ```
 
 ### 2. Apply the Harness to an Existing iOS Project
@@ -178,10 +164,10 @@ Use this when the app already exists and SwiftNest should reflect the current pr
 Recommended flow:
 
 1. Inspect the existing architecture, frameworks, permission surfaces, testing style, and naming conventions.
-2. Install the managed SwiftNest files into the repository root.
-3. Create `config/project.yaml` from the real project, not from aspiration.
-4. Choose the profile and skills that match the current codebase.
-5. Run `init`, review the generated docs against the current project, and commit them.
+2. Run `onboard` into the repository root so SwiftNest installs, infers config defaults, and initializes docs together.
+3. Review `config/project.yaml` so it reflects the real project, not an aspiration.
+4. Choose the profile, skills, and workflows that match the current codebase when rerunning onboarding or init with explicit options.
+5. Review the generated docs against the current project and commit them.
 
 Example:
 
@@ -189,13 +175,11 @@ Example:
 cd /path/to/existing-ios-repo
 
 git clone https://github.com/oozoofrog/swift-nest.git /tmp/swift-nest
-/tmp/swift-nest/swiftnest install --target "$PWD"
-
-test -f config/project.yaml || cp config/project.example.yaml config/project.yaml
-./swiftnest init \
-  --config config/project.yaml \
+/tmp/swift-nest/swiftnest onboard \
+  --target "$PWD" \
   --profile intermediate \
-  --skills ios-architecture,swiftui-rules,concurrency-rules,networking-rules,testing-rules
+  --skills ios-architecture,swiftui-rules,concurrency-rules,networking-rules,testing-rules \
+  --workflows networking,review
 ```
 
 If the project already includes location, HealthKit, or logging-heavy code paths, add those skills explicitly during initialization. Optional workflow scaffolds such as `permissions`, `networking`, or `review` can be added later with `./swiftnest workflow scaffold ...`.
@@ -206,7 +190,7 @@ Use this when you want a low-friction starting point first and stricter rules on
 
 Recommended flow:
 
-1. Install SwiftNest once and initialize it with `basic` or `intermediate`.
+1. Install SwiftNest once and onboard with `basic` or `intermediate`.
 2. Let the team work with SwiftNest for a while.
 3. Add skills as new domains become real in the codebase.
 4. Upgrade the profile when review discipline needs to become stricter.
@@ -215,10 +199,10 @@ Recommended flow:
 Example:
 
 ```bash
-./swiftnest init \
-  --config config/project.yaml \
+./swiftnest onboard \
   --profile basic \
-  --skills ios-architecture,swiftui-rules,testing-rules
+  --skills ios-architecture,swiftui-rules,testing-rules \
+  --non-interactive
 
 ./swiftnest upgrade --to intermediate
 ./swiftnest upgrade --to advanced
@@ -314,16 +298,15 @@ Follow this process:
 1. Clone or download the starter repository into a temporary directory.
 2. Read the README from the starter repository first.
 3. From the starter checkout, run:
-   ./swiftnest install --target <CURRENT_REPOSITORY_ROOT>
-4. In the current repository, create config/project.yaml from config/project.example.yaml if it does not exist yet.
-5. Edit config/project.yaml so it reflects the actual project state.
-6. Choose an appropriate profile and skills for this codebase.
-7. From the current repository root, run ./swiftnest init --config config/project.yaml with explicit profile and skills.
-8. Keep Docs/ and .ai-harness/ checked into the repository.
-9. Summarize the selected profile, selected skills, generated files, and any assumptions.
+   ./swiftnest onboard --target <CURRENT_REPOSITORY_ROOT>
+4. Review config/project.yaml so it reflects the actual project state.
+5. Review the generated AGENTS.md, Docs/, and .ai-harness/ output.
+6. If needed, rerun ./swiftnest onboard or ./swiftnest init with explicit profile, skills, or workflows.
+7. Keep Docs/ and .ai-harness/ checked into the repository.
+8. Summarize the selected profile, selected skills, generated files, and any assumptions.
 
 Constraints:
-- Do not run ./swiftnest init from the starter checkout when the goal is to modify the current repository.
+- Do not run ./swiftnest onboard or ./swiftnest init from the starter checkout when the goal is to modify the current repository.
 - Do not break the existing Xcode project structure.
 - Do not ignore .ai-harness/.
 - Prefer minimal, reviewable changes.
@@ -351,6 +334,8 @@ Paths inside the state file are stored relative to the repository when possible,
 From a starter checkout or any repository that already contains the managed SwiftNest files:
 
 ```bash
+./swiftnest onboard --target /path/to/app-repo
+make onboard TARGET=/path/to/app-repo
 ./swiftnest install --target /path/to/app-repo
 make install-swiftnest TARGET=/path/to/app-repo
 ```
@@ -358,9 +343,11 @@ make install-swiftnest TARGET=/path/to/app-repo
 From a repository where SwiftNest has already been installed:
 
 ```bash
+./swiftnest onboard
+make onboard CONFIG=config/project.yaml
 ./swiftnest list-skills
 ./swiftnest list-profiles
-./swiftnest init --config config/project.yaml
+./swiftnest init --config config/project.yaml --workflows permissions,review
 ./swiftnest workflow list
 ./swiftnest workflow print add-feature
 ./swiftnest workflow scaffold permissions review

--- a/README_kr.md
+++ b/README_kr.md
@@ -50,26 +50,21 @@ Docs/
 에이전트가 이 GitHub 링크만 받은 경우, 기대하는 설치 순서는 아래와 같습니다.
 
 1. 이 스타터를 임시 디렉터리에 clone 또는 download 합니다.
-2. 스타터 체크아웃에서 대상 앱 저장소로 shell entrypoint를 실행합니다.
-3. 대상 저장소 안에서 `config/project.yaml` 을 만듭니다.
-4. 대상 저장소에서 `init` 를 실행해서 생성 파일이 스타터가 아니라 앱 저장소 안에 생기게 합니다.
+2. 스타터 체크아웃에서 `onboard` 로 대상 앱 저장소에 SwiftNest를 설치합니다.
+3. 대상 저장소 안의 `config/project.yaml`, `AGENTS.md`, `Docs/` 생성 결과를 검토합니다.
+4. 대상 저장소 루트에서 에이전트 작업을 시작합니다.
 5. 대상 저장소에서 생성된 `Docs/` 와 `.ai-harness/` 를 커밋합니다.
 
 예시:
 
 ```bash
 git clone https://github.com/oozoofrog/swift-nest.git /tmp/swift-nest
-/tmp/swift-nest/swiftnest install --target /path/to/current-ios-repo
-
-cd /path/to/current-ios-repo
-test -f config/project.yaml || cp config/project.example.yaml config/project.yaml
-./swiftnest init \
-  --config config/project.yaml \
-  --profile intermediate \
-  --skills ios-architecture,swiftui-rules,concurrency-rules,networking-rules,testing-rules
+/tmp/swift-nest/swiftnest onboard \
+  --target /path/to/current-ios-repo \
+  --non-interactive
 ```
 
-첫 실행 시 `tools/swiftnest-cli/.build/` 아래에 로컬 Swift 바이너리를 빌드합니다. 다른 저장소에 SwiftNest를 설치하는 것이 목적이라면, 스타터 체크아웃 안에서 `./swiftnest init` 를 실행하면 안 됩니다.
+첫 실행 시 `tools/swiftnest-cli/.build/` 아래에 로컬 Swift 바이너리를 빌드합니다. 다른 저장소에 SwiftNest를 설치하는 것이 목적이라면, 스타터 체크아웃 안에서 `./swiftnest onboard` 나 `./swiftnest init` 를 실행하면 안 됩니다.
 
 ## Homebrew 패키징
 
@@ -90,7 +85,7 @@ tap 이 공개된 이후 기대하는 설치 흐름은 아래와 같습니다.
 ```bash
 brew tap oozoofrog/swiftnest https://github.com/oozoofrog/homebrew-swiftnest
 brew install swiftnest
-swiftnest install --target /path/to/current-ios-repo
+swiftnest onboard --target /path/to/current-ios-repo
 ```
 
 Homebrew로 설치된 전역 `swiftnest` 는 bootstrap 용도에 맞춰 설계됩니다. 현재 디렉터리에 repo-local `./swiftnest` 가 이미 있다면, tap wrapper 는 그 로컬 엔트리포인트로 위임해서 이후 명령이 계속 저장소 복사본을 기준으로 실행되게 해야 합니다.
@@ -101,34 +96,31 @@ repo-local `./swiftnest` 스크립트는 첫 실행 시 여전히 로컬 macOS S
 
 이 섹션은 현재 저장소에 이미 하네스 관리 파일이 들어 있고, macOS Swift toolchain 을 사용할 수 있다고 가정합니다.
 
-### 1. 예제 설정 파일 복사
+### 1. 온보딩 실행
+
+```bash
+./swiftnest onboard
+```
+
+### 2. 비대화식 온보딩 실행
+
+```bash
+./swiftnest onboard \
+  --config config/project.yaml \
+  --profile intermediate \
+  --skills ios-architecture,swiftui-rules,concurrency-rules,testing-rules,location-rules \
+  --workflows permissions,review \
+  --non-interactive
+```
+
+### 3. 더 세밀한 제어가 필요할 때 하위 명령 사용
 
 ```bash
 cp config/project.example.yaml config/project.yaml
-```
-
-### 2. 값 수정
-
-`config/project.yaml` 안의 값을 현재 프로젝트에 맞게 수정합니다.
-
-프로젝트에서 선호하는 verification 명령이 이미 정해져 있다면, optional `build_command` 와 `test_command` 도 함께 채워두면 좋습니다.
-
-### 3. 인터랙티브 초기화 실행
-
-```bash
 ./swiftnest init --config config/project.yaml
 ```
 
-### 4. 비대화식 초기화 실행
-
-```bash
-./swiftnest init \
-  --config config/project.yaml \
-  --profile intermediate \
-  --skills ios-architecture,swiftui-rules,concurrency-rules,testing-rules,location-rules
-```
-
-### 5. 이후 rerender 또는 upgrade
+### 4. 이후 rerender 또는 upgrade
 
 ```bash
 ./swiftnest render-context
@@ -149,10 +141,10 @@ cp config/project.example.yaml config/project.yaml
 
 1. 새 저장소를 만들거나 빈 저장소 루트로 이동합니다.
 2. 이 스타터를 임시 디렉터리에 clone 합니다.
-3. 새 저장소에 SwiftNest 관리 파일을 설치합니다.
-4. `config/project.yaml` 을 만들고 의도하는 앱 문맥을 채웁니다.
-5. 가벼운 프로필과 작은 스킬 세트부터 시작합니다.
-6. `init` 를 실행하고 생성된 `Docs/` 와 `.ai-harness/` 를 커밋합니다.
+3. `onboard` 로 새 저장소에 SwiftNest를 설치하고 설정 및 문서 생성을 한 번에 진행합니다.
+4. `config/project.yaml` 과 생성된 `AGENTS.md` 를 검토합니다.
+5. 필요하다면 가벼운 프로필과 작은 스킬 세트로 온보딩을 다시 실행합니다.
+6. 생성된 `Docs/` 와 `.ai-harness/` 를 커밋합니다.
 
 예시:
 
@@ -162,13 +154,7 @@ cd MyNewApp
 git init
 
 git clone https://github.com/oozoofrog/swift-nest.git /tmp/swift-nest
-/tmp/swift-nest/swiftnest install --target "$PWD"
-
-cp config/project.example.yaml config/project.yaml
-./swiftnest init \
-  --config config/project.yaml \
-  --profile basic \
-  --skills ios-architecture,swiftui-rules,testing-rules
+/tmp/swift-nest/swiftnest onboard --target "$PWD"
 ```
 
 ### 2. 이미 존재하는 iOS 프로젝트 상태에 맞춰 하네스를 적용하는 경우
@@ -178,10 +164,10 @@ cp config/project.example.yaml config/project.yaml
 권장 흐름:
 
 1. 현재 프로젝트의 아키텍처, 프레임워크 사용, 권한 영역, 테스트 스타일을 먼저 확인합니다.
-2. 저장소 루트에 SwiftNest 관리 파일을 설치합니다.
-3. 실제 프로젝트 상태를 반영해서 `config/project.yaml` 을 작성합니다.
-4. 현재 코드베이스에 맞는 프로필과 스킬을 고릅니다.
-5. `init` 를 실행한 뒤, 생성된 문서가 현재 프로젝트 관습과 맞는지 검토하고 커밋합니다.
+2. 저장소 루트에 `onboard` 를 실행해서 SwiftNest 설치, 설정 기본값 생성, 문서 초기화를 함께 수행합니다.
+3. 실제 프로젝트 상태를 반영하도록 `config/project.yaml` 을 검토합니다.
+4. 현재 코드베이스에 맞는 프로필, 스킬, 워크플로를 필요에 따라 명시합니다.
+5. 생성된 문서가 현재 프로젝트 관습과 맞는지 검토하고 커밋합니다.
 
 예시:
 
@@ -189,13 +175,11 @@ cp config/project.example.yaml config/project.yaml
 cd /path/to/existing-ios-repo
 
 git clone https://github.com/oozoofrog/swift-nest.git /tmp/swift-nest
-/tmp/swift-nest/swiftnest install --target "$PWD"
-
-test -f config/project.yaml || cp config/project.example.yaml config/project.yaml
-./swiftnest init \
-  --config config/project.yaml \
+/tmp/swift-nest/swiftnest onboard \
+  --target "$PWD" \
   --profile intermediate \
-  --skills ios-architecture,swiftui-rules,concurrency-rules,networking-rules,testing-rules
+  --skills ios-architecture,swiftui-rules,concurrency-rules,networking-rules,testing-rules \
+  --workflows networking,review
 ```
 
 프로젝트에 위치 권한, HealthKit, 구조화 로그가 이미 중요하게 들어가 있다면 해당 스킬도 초기화 시점에 함께 추가하는 것이 좋습니다. `permissions`, `networking`, `review` 같은 optional workflow scaffold는 이후 `./swiftnest workflow scaffold ...`로 추가합니다.
@@ -206,7 +190,7 @@ test -f config/project.yaml || cp config/project.example.yaml config/project.yam
 
 권장 흐름:
 
-1. SwiftNest를 한 번 설치한 뒤 `basic` 또는 `intermediate` 로 초기화합니다.
+1. SwiftNest를 한 번 설치한 뒤 `basic` 또는 `intermediate` 로 온보딩합니다.
 2. 일정 기간 팀이 실제로 SwiftNest를 사용하게 둡니다.
 3. 새 도메인이 코드베이스에 생기면 스킬을 추가합니다.
 4. 리뷰 기준을 강화할 필요가 생기면 프로필을 업그레이드합니다.
@@ -215,10 +199,10 @@ test -f config/project.yaml || cp config/project.example.yaml config/project.yam
 예시:
 
 ```bash
-./swiftnest init \
-  --config config/project.yaml \
+./swiftnest onboard \
   --profile basic \
-  --skills ios-architecture,swiftui-rules,testing-rules
+  --skills ios-architecture,swiftui-rules,testing-rules \
+  --non-interactive
 
 ./swiftnest upgrade --to intermediate
 ./swiftnest upgrade --to advanced
@@ -314,16 +298,15 @@ Follow this process:
 1. Clone or download the starter repository into a temporary directory.
 2. Read the README from the starter repository first.
 3. From the starter checkout, run:
-   ./swiftnest install --target <CURRENT_REPOSITORY_ROOT>
-4. In the current repository, create config/project.yaml from config/project.example.yaml if it does not exist yet.
-5. Edit config/project.yaml so it reflects the actual project state.
-6. Choose an appropriate profile and skills for this codebase.
-7. From the current repository root, run ./swiftnest init --config config/project.yaml with explicit profile and skills.
-8. Keep Docs/ and .ai-harness/ checked into the repository.
-9. Summarize the selected profile, selected skills, generated files, and any assumptions.
+   ./swiftnest onboard --target <CURRENT_REPOSITORY_ROOT>
+4. Review config/project.yaml so it reflects the actual project state.
+5. Review the generated AGENTS.md, Docs/, and .ai-harness/ output.
+6. If needed, rerun ./swiftnest onboard or ./swiftnest init with explicit profile, skills, or workflows.
+7. Keep Docs/ and .ai-harness/ checked into the repository.
+8. Summarize the selected profile, selected skills, generated files, and any assumptions.
 
 Constraints:
-- Do not run ./swiftnest init from the starter checkout when the goal is to modify the current repository.
+- Do not run ./swiftnest onboard or ./swiftnest init from the starter checkout when the goal is to modify the current repository.
 - Do not break the existing Xcode project structure.
 - Do not ignore .ai-harness/.
 - Prefer minimal, reviewable changes.
@@ -351,6 +334,8 @@ Constraints:
 스타터 체크아웃 또는 이미 SwiftNest 관리 파일이 들어 있는 저장소에서:
 
 ```bash
+./swiftnest onboard --target /path/to/app-repo
+make onboard TARGET=/path/to/app-repo
 ./swiftnest install --target /path/to/app-repo
 make install-swiftnest TARGET=/path/to/app-repo
 ```
@@ -358,9 +343,11 @@ make install-swiftnest TARGET=/path/to/app-repo
 SwiftNest가 이미 설치된 저장소에서:
 
 ```bash
+./swiftnest onboard
+make onboard CONFIG=config/project.yaml
 ./swiftnest list-skills
 ./swiftnest list-profiles
-./swiftnest init --config config/project.yaml
+./swiftnest init --config config/project.yaml --workflows permissions,review
 ./swiftnest workflow list
 ./swiftnest workflow print add-feature
 ./swiftnest workflow scaffold permissions review

--- a/config/project.example.yaml
+++ b/config/project.example.yaml
@@ -1,5 +1,5 @@
-project_name: RunTrack
-optional_watchos_line: "/ watchOS companion app enabled"
+project_name: MyApp
+optional_watchos_line: ""
 ui_framework: SwiftUI
 architecture_style: MVVM with Repository pattern
 min_ios_version: iOS 17
@@ -10,7 +10,7 @@ network_layer_name: APIClient + RemoteRepository
 persistence_layer_name: LocalRepository
 logging_system: OSLog
 privacy_requirements: App Privacy disclosure and least-privilege data handling
-preferred_file_line_limit: "300"
+preferred_file_line_limit: 300
 healthkit_layer_name: HealthKitManager
-build_command: xcodebuild -scheme RunTrack build
-test_command: xcodebuild test -scheme RunTrack
+build_command: ""
+test_command: ""

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -48,6 +48,6 @@ For the feature-to-release handoff sequence after work lands on `main`, see the 
 The rendered Homebrew wrapper should:
 
 - set `SWIFTNEST_ROOT` to the formula `libexec`
-- allow bootstrap commands from the global installation (`install`, `list-skills`, `list-profiles`, and help)
+- allow bootstrap commands from the global installation (`onboard`, `install`, `list-skills`, `list-profiles`, and help)
 - delegate to `./swiftnest` when the current directory already contains a repo-local installation
 - print a clear error for commands like `init` when no repo-local installation exists yet

--- a/packaging/homebrew/swiftnest.rb.template
+++ b/packaging/homebrew/swiftnest.rb.template
@@ -93,7 +93,7 @@ class Swiftnest < Formula
       command_name="$(first_non_lang_arg "$@")"
 
       case "$command_name" in
-        ""|-h|--help|help|install|list-skills|list-profiles)
+        ""|-h|--help|help|onboard|install|list-skills|list-profiles)
           export SWIFTNEST_ROOT="#{libexec}"
           exec "#{libexec}/bin/swiftnest" "$@"
           ;;
@@ -102,11 +102,11 @@ class Swiftnest < Formula
       case "$(resolve_lang "$@")" in
         ko)
           echo "오류: Homebrew로 설치한 swiftnest 명령은 저장소 부트스트랩 용도로만 사용할 수 있습니다." >&2
-          echo "먼저 'swiftnest install --target <path>'를 실행한 뒤, 대상 저장소에서 './swiftnest ...'를 사용하세요." >&2
+          echo "먼저 'swiftnest onboard --target <path>' 또는 'swiftnest install --target <path>'를 실행한 뒤, 대상 저장소에서 './swiftnest ...'를 사용하세요." >&2
           ;;
         *)
           echo "error: the Homebrew-installed swiftnest command only bootstraps repositories." >&2
-          echo "Run 'swiftnest install --target <path>' first, then use './swiftnest ...' from the target repository." >&2
+          echo "Run 'swiftnest onboard --target <path>' or 'swiftnest install --target <path>' first, then use './swiftnest ...' from the target repository." >&2
           ;;
       esac
       exit 1
@@ -119,9 +119,12 @@ class Swiftnest < Formula
     assert_match "개인 프로젝트", shell_output("SWIFTNEST_LANG=ko #{bin}/swiftnest list-profiles")
 
     target = testpath/"sample-repo"
-    system "#{bin}/swiftnest", "--lang", "ko", "install", "--target", target
+    system "#{bin}/swiftnest", "--lang", "ko", "onboard", "--target", target, "--non-interactive"
 
     assert_predicate target/"swiftnest", :exist?
+    assert_predicate target/"config/project.yaml", :exist?
+    assert_predicate target/"AGENTS.md", :exist?
+    assert_predicate target/".ai-harness/state.json", :exist?
     assert_predicate target/"profiles/advanced.yaml", :exist?
     assert_predicate target/"templates/Docs/AI_RULES.md", :exist?
     assert_predicate target/"tools/swiftnest-cli/Sources/SwiftNestCLI.swift", :exist?

--- a/tools/swiftnest-cli/Sources/SwiftNestCLI.swift
+++ b/tools/swiftnest-cli/Sources/SwiftNestCLI.swift
@@ -81,6 +81,9 @@ struct SwiftNestRepository {
     var configURL: URL { rootURL.appendingPathComponent("config", isDirectory: true) }
     var stateDirectoryURL: URL { rootURL.appendingPathComponent(".ai-harness", isDirectory: true) }
     var stateFileURL: URL { stateDirectoryURL.appendingPathComponent("state.json") }
+    var isStarterCheckout: Bool {
+        fileManager.fileExists(atPath: rootURL.appendingPathComponent("packaging/homebrew/swiftnest.rb.template").path)
+    }
 
     static func locate() throws -> SwiftNestRepository {
         let environment = ProcessInfo.processInfo.environment
@@ -114,7 +117,7 @@ struct SwiftNestRepository {
         throw SwiftNestError(SwiftNestLocalizer.text(.couldNotLocateRepositoryRoot))
     }
 
-    private static func isRepositoryRoot(_ url: URL) -> Bool {
+    static func isRepositoryRoot(_ url: URL) -> Bool {
         let fileManager = FileManager.default
         return fileManager.fileExists(atPath: url.appendingPathComponent("templates/Docs/AI_RULES.md").path)
             && fileManager.fileExists(atPath: url.appendingPathComponent("profiles").path)
@@ -217,6 +220,17 @@ enum SwiftNestCLI {
         let remaining = Array(arguments.dropFirst())
 
         switch command {
+        case "onboard":
+            let parsed = try parse(
+                remaining,
+                valueOptions: ["--target", "--config", "--profile", "--skills", "--workflows"],
+                flagOptions: ["--non-interactive", "--force", "--help", "-h"]
+            )
+            if parsed.contains("--help") || parsed.contains("-h") {
+                printOnboardUsage()
+                return
+            }
+            try runOnboard(parsed: parsed, repository: repository)
         case "install":
             let parsed = try parse(remaining, valueOptions: ["--target"], flagOptions: ["--force", "--dry-run", "--help", "-h"])
             if parsed.contains("--help") || parsed.contains("-h") {
@@ -225,7 +239,11 @@ enum SwiftNestCLI {
             }
             try runInstall(parsed: parsed, repository: repository)
         case "init":
-            let parsed = try parse(remaining, valueOptions: ["--config", "--profile", "--skills"], flagOptions: ["--non-interactive", "--help", "-h"])
+            let parsed = try parse(
+                remaining,
+                valueOptions: ["--config", "--profile", "--skills", "--workflows"],
+                flagOptions: ["--non-interactive", "--help", "-h"]
+            )
             if parsed.contains("--help") || parsed.contains("-h") {
                 printInitUsage()
                 return
@@ -297,8 +315,7 @@ enum SwiftNestCLI {
         if !parsed.contains("--dry-run") {
             print(SwiftNestLocalizer.text(.nextSteps))
             print("  cd \(targetURL.path)")
-            print("  test -f config/project.yaml || cp config/project.example.yaml config/project.yaml")
-            print(SwiftNestLocalizer.text(.editProjectConfig))
+            print("  ./swiftnest onboard --config config/project.yaml")
             print("  ./swiftnest init --config config/project.yaml --profile intermediate")
         }
     }
@@ -316,66 +333,33 @@ enum SwiftNestCLI {
 
         let configURL = URL(fileURLWithPath: configValue, relativeTo: repository.rootURL).standardizedFileURL
         let config = try HarnessDocumentLoader.loadObject(at: configURL)
+        let interactive = shouldRunInteractively(parsed: parsed)
 
-        let profileName = try parsed.value(for: "--profile") ?? chooseProfileInteractively(repository: repository)
+        let profileName = try resolveOnboardingProfile(parsed: parsed, repository: repository, interactive: interactive)
         let profile = try HarnessDocumentLoader.loadObject(at: repository.profileURL(named: profileName))
         let defaultSkills = HarnessDocumentLoader.stringArray(profile, key: "default_skills")
-
-        let skills: [String]
-        if let rawSkills = parsed.value(for: "--skills"), !rawSkills.isEmpty {
-            skills = Array(Set(rawSkills.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty })).sorted()
-        } else if parsed.contains("--non-interactive") {
-            skills = defaultSkills
-        } else {
-            skills = try chooseSkillsInteractively(defaultSkills: defaultSkills, repository: repository)
-        }
-
-        let workflows = defaultWorkflowNames
-        let context = mergedContext(
-            base: try normalizeContext(config: config, profileName: profileName),
-            extra: workflowContext(config: config, skills: skills, workflows: workflows)
+        let skills = try resolveOnboardingSkills(
+            parsed: parsed,
+            defaultSkills: defaultSkills,
+            repository: repository,
+            interactive: interactive
         )
-        try writeDocs(context: context, skills: skills, profileName: profileName, repository: repository)
-        let renderedWorkflows = try scaffoldWorkflowFiles(
+        let workflows = try resolveOnboardingWorkflows(
+            parsed: parsed,
+            interactive: interactive,
+            repository: repository
+        )
+        let state = try initializeHarness(
             config: config,
+            configURL: configURL,
             profileName: profileName,
             skills: skills,
             workflows: workflows,
             repository: repository
         )
-        try writeAgentsFile(
-            config: config,
-            profileName: profileName,
-            skills: skills,
-            workflows: renderedWorkflows,
-            repository: repository
-        )
-        let contextURL = try renderContextBundle(
-            profileName: profileName,
-            skills: skills,
-            workflows: renderedWorkflows,
-            repository: repository
-        )
-
-        try repository.fileManager.createDirectory(at: repository.stateDirectoryURL, withIntermediateDirectories: true)
-        let selectedProfileURL = repository.stateDirectoryURL.appendingPathComponent("selected_profile.yaml")
-        let selectedSkillsURL = repository.stateDirectoryURL.appendingPathComponent("selected_skills.txt")
-        let profileSourceURL = try repository.profileURL(named: profileName)
-        let profileText = try String(contentsOf: profileSourceURL, encoding: .utf8)
-        try profileText.write(to: selectedProfileURL, atomically: true, encoding: .utf8)
-        try (skills.joined(separator: "\n") + "\n").write(to: selectedSkillsURL, atomically: true, encoding: .utf8)
-
-        let state = SwiftNestState(
-            profile: profileName,
-            skills: skills,
-            workflows: renderedWorkflows,
-            configPath: repository.serializeStatePath(configURL),
-            contextPath: repository.serializeStatePath(contextURL)
-        )
-        try repository.saveState(state)
 
         print(SwiftNestLocalizer.text(.initializedSwiftNest, profileName, skills.joined(separator: ", ")))
-        print(SwiftNestLocalizer.text(.renderedContext, contextURL.path))
+        print(SwiftNestLocalizer.text(.renderedContext, repository.resolveStatePath(state.contextPath).path))
     }
 
     static func runUpgrade(parsed: ParsedArguments, repository: SwiftNestRepository) throws {
@@ -797,19 +781,26 @@ enum SwiftNestCLI {
         return outputURL
     }
 
-    static func chooseProfileInteractively(repository: SwiftNestRepository) throws -> String {
-        let profiles = try repository.availableProfiles().map { $0.deletingPathExtension().lastPathComponent }
-        print(SwiftNestLocalizer.text(.profilesHeader))
-        for (index, name) in profiles.enumerated() {
-            print("  \(index + 1). \(name)")
+    static func chooseProfileInteractively(
+        repository: SwiftNestRepository,
+        defaultProfileName: String = defaultOnboardingProfileName
+    ) throws -> String {
+        let profiles = try repository.availableProfiles().map { profileURL -> (String, String) in
+            let data = try HarnessDocumentLoader.loadObject(at: profileURL)
+            return (profileURL.deletingPathExtension().lastPathComponent, localizedProfileDescription(from: data))
         }
-        print(SwiftNestLocalizer.text(.chooseProfileNumberPrompt), terminator: "")
+        print(SwiftNestLocalizer.text(.profilesHeader))
+        for (index, profile) in profiles.enumerated() {
+            print("  \(index + 1). \(profile.0) — \(profile.1)")
+        }
+        let defaultNumber = profiles.firstIndex { $0.0 == defaultProfileName }.map { String($0 + 1) } ?? "1"
+        print(SwiftNestLocalizer.text(.chooseProfileNumberPrompt, defaultNumber), terminator: "")
         let raw = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let chosen = raw.isEmpty ? "1" : raw
+        let chosen = raw.isEmpty ? defaultNumber : raw
         guard let number = Int(chosen), profiles.indices.contains(number - 1) else {
             throw SwiftNestError(SwiftNestLocalizer.text(.profileChoiceOutOfRange))
         }
-        return profiles[number - 1]
+        return profiles[number - 1].0
     }
 
     static func chooseSkillsInteractively(defaultSkills: [String], repository: SwiftNestRepository) throws -> [String] {
@@ -817,12 +808,13 @@ enum SwiftNestCLI {
         print(SwiftNestLocalizer.text(.availableSkillsHeader))
         for (index, skill) in skills.enumerated() {
             let mark = defaultSkills.contains(skill) ? "*" : " "
-            print(String(format: "  %2d. [%@] %@", index + 1, mark, skill))
+            let summary = skillSummary(named: skill, repository: repository)
+            print(String(format: "  %2d. [%@] %@ — %@", index + 1, mark, skill, summary))
         }
         print(SwiftNestLocalizer.text(.selectSkillsPrompt), terminator: "")
         let raw = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if raw.isEmpty {
-            return defaultSkills
+            return defaultSkills.sorted()
         }
 
         var chosen: [String] = []
@@ -962,6 +954,10 @@ enum SwiftNestCLI {
 
     static func printInstallUsage() {
         print(SwiftNestLocalizer.text(.usageInstall))
+    }
+
+    static func printOnboardUsage() {
+        print(SwiftNestLocalizer.text(.usageOnboard))
     }
 
     static func printInitUsage() {

--- a/tools/swiftnest-cli/Sources/SwiftNestLocalization.swift
+++ b/tools/swiftnest-cli/Sources/SwiftNestLocalization.swift
@@ -47,6 +47,42 @@ enum SwiftNestMessageKey: Hashable {
     case unknownProfile
     case noStateFile
     case unknownCommand
+    case unexpectedPositionalsOnboard
+    case onboardingRequiresTargetOutsideRepository
+    case onboardingStarterCheckoutRequiresTarget
+    case onboardingStarted
+    case onboardingStarterPath
+    case onboardingTargetPath
+    case onboardingManagedFilesReady
+    case onboardingCreatedConfig
+    case onboardingUsingExistingConfig
+    case onboardingAlreadyCompleted
+    case onboardingCurrentProfile
+    case onboardingCurrentSkills
+    case onboardingCurrentWorkflows
+    case onboardingUseForceToRerun
+    case onboardingCompleted
+    case onboardingConfigReady
+    case onboardingGeneratedFilesHeader
+    case onboardingHowAgentsUseThisHeader
+    case onboardingHowAgentsUseThisLine1
+    case onboardingHowAgentsUseThisLine2
+    case onboardingNextStepsHeader
+    case onboardingNextStepReviewConfig
+    case onboardingNextStepReviewAgents
+    case onboardingNextStepAgentRoot
+    case onboardingConfigPromptHeader
+    case onboardingPromptProjectName
+    case onboardingPromptWatchCompanion
+    case onboardingPromptUIFramework
+    case onboardingPromptArchitectureStyle
+    case onboardingPromptNetworkLayerName
+    case onboardingPromptPersistenceLayerName
+    case onboardingPromptLoggingSystem
+    case onboardingPromptBuildCommand
+    case onboardingPromptTestCommand
+    case onboardingPromptBooleanRetry
+    case onboardingSkillSummaryFallback
     case unexpectedPositionalsInstall
     case installRequiresTarget
     case targetRepositoryMustDiffer
@@ -87,7 +123,9 @@ enum SwiftNestMessageKey: Hashable {
     case chooseProfileNumberPrompt
     case profileChoiceOutOfRange
     case availableSkillsHeader
+    case availableWorkflowsHeader
     case selectSkillsPrompt
+    case selectWorkflowsPrompt
     case invalidSelection
     case selectionOutOfRange
     case expectedFileButFoundDirectory
@@ -100,6 +138,7 @@ enum SwiftNestMessageKey: Hashable {
     case warningDocsAlreadyExists
     case warningAIHarnessAlreadyExists
     case usageTopLevel
+    case usageOnboard
     case usageInstall
     case usageInit
     case usageUpgrade
@@ -148,7 +187,7 @@ enum SwiftNestLocalizer {
             .errorPrefix: "error",
             .wrapperSwiftRequired: "swift is required to build the SwiftNest CLI on macOS.",
             .homebrewBootstrapOnlyLine1: "error: the Homebrew-installed swiftnest command only bootstraps repositories.",
-            .homebrewBootstrapOnlyLine2: "Run 'swiftnest install --target <path>' first, then use './swiftnest ...' from the target repository.",
+            .homebrewBootstrapOnlyLine2: "Run 'swiftnest onboard --target <path>' or 'swiftnest install --target <path>' first, then use './swiftnest ...' from the target repository.",
             .unsupportedLanguageOption: "Unsupported language value for --lang: %@. Supported values: %@.",
             .unsupportedLanguageEnvironment: "Unsupported language value for SWIFTNEST_LANG: %@. Supported values: %@.",
             .missingValueForOption: "Missing value for %@.",
@@ -158,6 +197,42 @@ enum SwiftNestLocalizer {
             .unknownProfile: "Unknown profile: %@",
             .noStateFile: "No .ai-harness/state.json found. Run init first.",
             .unknownCommand: "Unknown command: %@",
+            .unexpectedPositionalsOnboard: "Unexpected positional arguments for onboard: %@",
+            .onboardingRequiresTargetOutsideRepository: "onboard requires --target <path> when you are not already inside a SwiftNest-managed repository.",
+            .onboardingStarterCheckoutRequiresTarget: "Running onboard from the SwiftNest starter checkout requires --target <path> so the target app repository is updated instead of the starter itself.",
+            .onboardingStarted: "Starting SwiftNest onboarding for %@",
+            .onboardingStarterPath: "Starter root: %@",
+            .onboardingTargetPath: "Target repository: %@",
+            .onboardingManagedFilesReady: "SwiftNest-managed files are already present in %@",
+            .onboardingCreatedConfig: "Created onboarding config: %@",
+            .onboardingUsingExistingConfig: "Using existing onboarding config: %@",
+            .onboardingAlreadyCompleted: "SwiftNest is already onboarded in %@.",
+            .onboardingCurrentProfile: "Profile: %@",
+            .onboardingCurrentSkills: "Skills: %@",
+            .onboardingCurrentWorkflows: "Workflows: %@",
+            .onboardingUseForceToRerun: "Re-run with --force to regenerate docs and state.",
+            .onboardingCompleted: "SwiftNest onboarding completed for %@.",
+            .onboardingConfigReady: "Config file: %@",
+            .onboardingGeneratedFilesHeader: "Generated files:",
+            .onboardingHowAgentsUseThisHeader: "How agents use this setup:",
+            .onboardingHowAgentsUseThisLine1: "- Agents should read AGENTS.md first, then follow Docs/AI_RULES.md, Docs/AI_WORKFLOWS.md, and Docs/AI_SKILLS/*.",
+            .onboardingHowAgentsUseThisLine2: "- The rendered context and workflow files under .ai-harness/ keep later agent runs aligned with the selected profile and workflows.",
+            .onboardingNextStepsHeader: "Recommended next steps:",
+            .onboardingNextStepReviewConfig: "- Review %@ and adjust project-specific values if needed.",
+            .onboardingNextStepReviewAgents: "- Review AGENTS.md to confirm the generated operating instructions.",
+            .onboardingNextStepAgentRoot: "- Start your AI task from %@ so the repository-local ./swiftnest and generated docs are available.",
+            .onboardingConfigPromptHeader: "Create config/project.yaml for this repository. Press Enter to accept inferred defaults.",
+            .onboardingPromptProjectName: "Project name",
+            .onboardingPromptWatchCompanion: "Include a watchOS companion line",
+            .onboardingPromptUIFramework: "UI framework",
+            .onboardingPromptArchitectureStyle: "Architecture style",
+            .onboardingPromptNetworkLayerName: "Networking boundary",
+            .onboardingPromptPersistenceLayerName: "Persistence boundary",
+            .onboardingPromptLoggingSystem: "Logging system",
+            .onboardingPromptBuildCommand: "Build command",
+            .onboardingPromptTestCommand: "Test command",
+            .onboardingPromptBooleanRetry: "Please answer with yes or no.",
+            .onboardingSkillSummaryFallback: "Review the generated skill file for details.",
             .unexpectedPositionalsInstall: "Unexpected positional arguments for install: %@",
             .installRequiresTarget: "install requires --target <path>.",
             .targetRepositoryMustDiffer: "Target repository must be different from the starter repository root.",
@@ -195,10 +270,12 @@ enum SwiftNestLocalizer {
             .unknownOption: "Unknown option: %@",
             .unknownSkillTemplate: "Unknown skill template: %@",
             .profilesHeader: "Profiles:",
-            .chooseProfileNumberPrompt: "Choose profile number (default 1): ",
+            .chooseProfileNumberPrompt: "Choose profile number (default %@): ",
             .profileChoiceOutOfRange: "Profile choice out of range",
             .availableSkillsHeader: "Available skills:",
+            .availableWorkflowsHeader: "Available workflows:",
             .selectSkillsPrompt: "Select skills by comma-separated numbers (Enter for defaults): ",
+            .selectWorkflowsPrompt: "Select optional workflows by comma-separated numbers (Enter for defaults): ",
             .invalidSelection: "Invalid selection: %@",
             .selectionOutOfRange: "Selection out of range: %@",
             .expectedFileButFoundDirectory: "Expected file but found directory at target path: %@",
@@ -214,6 +291,7 @@ enum SwiftNestLocalizer {
             usage: swiftnest [--lang <en|ko>] <command> [options]
 
             Commands:
+              onboard        Install, configure, and initialize SwiftNest for a repository
               install        Install SwiftNest-managed files into a target repository
               init           Initialize docs from config, profile, and skills
               upgrade        Upgrade to a stricter profile
@@ -222,8 +300,9 @@ enum SwiftNestLocalizer {
               list-skills    List available skills
               list-profiles  List available profiles
             """,
+            .usageOnboard: "usage: swiftnest [--lang <en|ko>] onboard [--target <path>] [--config <path>] [--profile <name>] [--skills <csv>] [--workflows <csv>] [--non-interactive] [--force]",
             .usageInstall: "usage: swiftnest [--lang <en|ko>] install --target <path> [--force] [--dry-run]",
-            .usageInit: "usage: swiftnest [--lang <en|ko>] init --config <path> [--profile <name>] [--skills <csv>] [--non-interactive]",
+            .usageInit: "usage: swiftnest [--lang <en|ko>] init --config <path> [--profile <name>] [--skills <csv>] [--workflows <csv>] [--non-interactive]",
             .usageUpgrade: "usage: swiftnest [--lang <en|ko>] upgrade --to <profile>",
             .usageWorkflow: """
             usage: swiftnest [--lang <en|ko>] workflow <subcommand> [options]
@@ -244,7 +323,7 @@ enum SwiftNestLocalizer {
             .errorPrefix: "오류",
             .wrapperSwiftRequired: "macOS에서 SwiftNest CLI를 빌드하려면 swift가 필요합니다.",
             .homebrewBootstrapOnlyLine1: "오류: Homebrew로 설치한 swiftnest 명령은 저장소 부트스트랩 용도로만 사용할 수 있습니다.",
-            .homebrewBootstrapOnlyLine2: "먼저 'swiftnest install --target <path>'를 실행한 뒤, 대상 저장소에서 './swiftnest ...'를 사용하세요.",
+            .homebrewBootstrapOnlyLine2: "먼저 'swiftnest onboard --target <path>' 또는 'swiftnest install --target <path>'를 실행한 뒤, 대상 저장소에서 './swiftnest ...'를 사용하세요.",
             .unsupportedLanguageOption: "--lang에 지원하지 않는 언어 값이 지정되었습니다: %@. 지원 값: %@.",
             .unsupportedLanguageEnvironment: "SWIFTNEST_LANG에 지원하지 않는 언어 값이 지정되었습니다: %@. 지원 값: %@.",
             .missingValueForOption: "%@ 옵션에 필요한 값이 없습니다.",
@@ -254,6 +333,42 @@ enum SwiftNestLocalizer {
             .unknownProfile: "알 수 없는 프로필입니다: %@",
             .noStateFile: ".ai-harness/state.json을 찾을 수 없습니다. 먼저 init을 실행하세요.",
             .unknownCommand: "알 수 없는 명령입니다: %@",
+            .unexpectedPositionalsOnboard: "onboard 명령에 예상하지 못한 위치 인자가 있습니다: %@",
+            .onboardingRequiresTargetOutsideRepository: "아직 SwiftNest가 설치되지 않은 위치에서 onboard를 실행하려면 --target <path>가 필요합니다.",
+            .onboardingStarterCheckoutRequiresTarget: "SwiftNest 스타터 체크아웃에서 onboard를 실행할 때는 스타터 자체가 아니라 대상 앱 저장소를 갱신하도록 --target <path>가 필요합니다.",
+            .onboardingStarted: "%@에 대한 SwiftNest 온보딩을 시작합니다",
+            .onboardingStarterPath: "스타터 루트: %@",
+            .onboardingTargetPath: "대상 저장소: %@",
+            .onboardingManagedFilesReady: "%@에는 이미 SwiftNest 관리 파일이 있습니다",
+            .onboardingCreatedConfig: "온보딩 설정 파일을 만들었습니다: %@",
+            .onboardingUsingExistingConfig: "기존 온보딩 설정 파일을 사용합니다: %@",
+            .onboardingAlreadyCompleted: "%@에는 이미 SwiftNest 온보딩이 완료되어 있습니다.",
+            .onboardingCurrentProfile: "프로필: %@",
+            .onboardingCurrentSkills: "스킬: %@",
+            .onboardingCurrentWorkflows: "워크플로: %@",
+            .onboardingUseForceToRerun: "--force와 함께 다시 실행하면 문서와 상태를 다시 생성합니다.",
+            .onboardingCompleted: "%@에 대한 SwiftNest 온보딩을 완료했습니다.",
+            .onboardingConfigReady: "설정 파일: %@",
+            .onboardingGeneratedFilesHeader: "생성된 파일:",
+            .onboardingHowAgentsUseThisHeader: "에이전트는 이 구성을 이렇게 사용합니다:",
+            .onboardingHowAgentsUseThisLine1: "- 에이전트는 먼저 AGENTS.md를 읽고, 이어서 Docs/AI_RULES.md, Docs/AI_WORKFLOWS.md, Docs/AI_SKILLS/*를 따릅니다.",
+            .onboardingHowAgentsUseThisLine2: "- .ai-harness/ 아래의 rendered context와 workflow 파일이 이후 작업을 선택한 프로필과 워크플로에 맞춰 정렬합니다.",
+            .onboardingNextStepsHeader: "권장 다음 단계:",
+            .onboardingNextStepReviewConfig: "- %@를 열어 프로젝트별 값을 검토하거나 수정하세요.",
+            .onboardingNextStepReviewAgents: "- 생성된 운영 지침이 맞는지 AGENTS.md를 검토하세요.",
+            .onboardingNextStepAgentRoot: "- %@ 루트에서 AI 작업을 시작하면 repo-local ./swiftnest와 생성된 문서를 바로 사용할 수 있습니다.",
+            .onboardingConfigPromptHeader: "이 저장소용 config/project.yaml을 만듭니다. Enter를 누르면 추론한 기본값을 사용합니다.",
+            .onboardingPromptProjectName: "프로젝트 이름",
+            .onboardingPromptWatchCompanion: "watchOS companion 라인 포함",
+            .onboardingPromptUIFramework: "UI 프레임워크",
+            .onboardingPromptArchitectureStyle: "아키텍처 스타일",
+            .onboardingPromptNetworkLayerName: "네트워크 경계",
+            .onboardingPromptPersistenceLayerName: "영속성 경계",
+            .onboardingPromptLoggingSystem: "로깅 시스템",
+            .onboardingPromptBuildCommand: "빌드 명령",
+            .onboardingPromptTestCommand: "테스트 명령",
+            .onboardingPromptBooleanRetry: "예 또는 아니오로 답해주세요.",
+            .onboardingSkillSummaryFallback: "자세한 내용은 생성된 스킬 문서를 확인하세요.",
             .unexpectedPositionalsInstall: "install 명령에 예상하지 못한 위치 인자가 있습니다: %@",
             .installRequiresTarget: "install 명령에는 --target <path>가 필요합니다.",
             .targetRepositoryMustDiffer: "대상 저장소는 스타터 저장소 루트와 달라야 합니다.",
@@ -291,10 +406,12 @@ enum SwiftNestLocalizer {
             .unknownOption: "알 수 없는 옵션입니다: %@",
             .unknownSkillTemplate: "알 수 없는 스킬 템플릿입니다: %@",
             .profilesHeader: "프로필:",
-            .chooseProfileNumberPrompt: "프로필 번호를 선택하세요 (기본값 1): ",
+            .chooseProfileNumberPrompt: "프로필 번호를 선택하세요 (기본값 %@): ",
             .profileChoiceOutOfRange: "프로필 선택이 범위를 벗어났습니다",
             .availableSkillsHeader: "사용 가능한 스킬:",
+            .availableWorkflowsHeader: "사용 가능한 워크플로:",
             .selectSkillsPrompt: "쉼표로 구분된 번호로 스킬을 선택하세요 (Enter 입력 시 기본값 사용): ",
+            .selectWorkflowsPrompt: "쉼표로 구분된 번호로 워크플로를 선택하세요 (Enter 입력 시 기본값 사용): ",
             .invalidSelection: "잘못된 선택입니다: %@",
             .selectionOutOfRange: "선택이 범위를 벗어났습니다: %@",
             .expectedFileButFoundDirectory: "대상 경로에서 파일이 와야 할 자리에 디렉터리가 있습니다: %@",
@@ -310,6 +427,7 @@ enum SwiftNestLocalizer {
             사용법: swiftnest [--lang <en|ko>] <command> [options]
 
             명령:
+              onboard        저장소에 SwiftNest를 설치, 설정, 초기화
               install        대상 저장소에 SwiftNest 관리 파일 설치
               init           설정, 프로필, 스킬로 문서 초기화
               upgrade        더 엄격한 프로필로 업그레이드
@@ -318,8 +436,9 @@ enum SwiftNestLocalizer {
               list-skills    사용 가능한 스킬 나열
               list-profiles  사용 가능한 프로필 나열
             """,
+            .usageOnboard: "사용법: swiftnest [--lang <en|ko>] onboard [--target <path>] [--config <path>] [--profile <name>] [--skills <csv>] [--workflows <csv>] [--non-interactive] [--force]",
             .usageInstall: "사용법: swiftnest [--lang <en|ko>] install --target <path> [--force] [--dry-run]",
-            .usageInit: "사용법: swiftnest [--lang <en|ko>] init --config <path> [--profile <name>] [--skills <csv>] [--non-interactive]",
+            .usageInit: "사용법: swiftnest [--lang <en|ko>] init --config <path> [--profile <name>] [--skills <csv>] [--workflows <csv>] [--non-interactive]",
             .usageUpgrade: "사용법: swiftnest [--lang <en|ko>] upgrade --to <profile>",
             .usageWorkflow: """
             사용법: swiftnest [--lang <en|ko>] workflow <subcommand> [options]

--- a/tools/swiftnest-cli/Sources/SwiftNestOnboarding.swift
+++ b/tools/swiftnest-cli/Sources/SwiftNestOnboarding.swift
@@ -1,0 +1,603 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+struct SwiftNestOnboardingConfigDraft {
+    var projectName: String
+    var includesWatchCompanion: Bool
+    var uiFramework: String
+    var architectureStyle: String
+    var minIOSVersion: String
+    var packageManager: String
+    var testFramework: String
+    var lintTools: String
+    var networkLayerName: String
+    var persistenceLayerName: String
+    var loggingSystem: String
+    var privacyRequirements: String
+    var preferredFileLineLimit: String
+    var healthKitLayerName: String
+    var buildCommand: String
+    var testCommand: String
+
+    func asDictionary() -> [String: String] {
+        [
+            "project_name": projectName,
+            "optional_watchos_line": includesWatchCompanion ? "/ watchOS companion app enabled" : "",
+            "ui_framework": uiFramework,
+            "architecture_style": architectureStyle,
+            "min_ios_version": minIOSVersion,
+            "package_manager": packageManager,
+            "test_framework": testFramework,
+            "lint_tools": lintTools,
+            "network_layer_name": networkLayerName,
+            "persistence_layer_name": persistenceLayerName,
+            "logging_system": loggingSystem,
+            "privacy_requirements": privacyRequirements,
+            "preferred_file_line_limit": preferredFileLineLimit,
+            "healthkit_layer_name": healthKitLayerName,
+            "build_command": buildCommand,
+            "test_command": testCommand,
+        ]
+    }
+}
+
+struct SwiftNestOnboardingStatus {
+    let starterRootURL: URL
+    let targetRootURL: URL
+    let targetAlreadyManaged: Bool
+    let configURL: URL
+    let configExists: Bool
+    let stateExists: Bool
+
+    var installsIntoDifferentRepository: Bool {
+        starterRootURL.standardizedFileURL.path != targetRootURL.standardizedFileURL.path
+    }
+}
+
+extension SwiftNestCLI {
+    static let defaultOnboardingProfileName = "intermediate"
+
+    static func runOnboard(parsed: ParsedArguments, repository: SwiftNestRepository) throws {
+        guard parsed.positionals.isEmpty else {
+            throw SwiftNestError(
+                SwiftNestLocalizer.text(.unexpectedPositionalsOnboard, parsed.positionals.joined(separator: " "))
+            )
+        }
+
+        let currentDirectoryURL = URL(
+            fileURLWithPath: repository.fileManager.currentDirectoryPath,
+            isDirectory: true
+        ).resolvingSymlinksInPath().standardizedFileURL
+        let targetURL = try resolveOnboardingTargetURL(
+            parsed: parsed,
+            repository: repository,
+            currentDirectoryURL: currentDirectoryURL
+        )
+        let configURL = resolveOnboardingConfigURL(parsed.value(for: "--config"), targetRootURL: targetURL)
+        var status = onboardingStatus(starterRepository: repository, targetRootURL: targetURL, configURL: configURL)
+        let interactive = shouldRunInteractively(parsed: parsed)
+
+        print(SwiftNestLocalizer.text(.onboardingStarted, status.targetRootURL.path))
+        print(SwiftNestLocalizer.text(.onboardingStarterPath, status.starterRootURL.path))
+        print(SwiftNestLocalizer.text(.onboardingTargetPath, status.targetRootURL.path))
+
+        if !status.targetAlreadyManaged {
+            let installResult = try installManagedFiles(
+                into: status.targetRootURL,
+                force: parsed.contains("--force"),
+                dryRun: false,
+                repository: repository
+            )
+            printWarnings(for: status.targetRootURL, fileManager: repository.fileManager)
+            print(SwiftNestLocalizer.text(.installedManagedFilesInto, status.targetRootURL.path))
+            print(SwiftNestLocalizer.text(.changedFiles, installResult.copied))
+            print(SwiftNestLocalizer.text(.unchangedFiles, installResult.unchanged))
+            status = onboardingStatus(starterRepository: repository, targetRootURL: status.targetRootURL, configURL: configURL)
+        } else {
+            print(SwiftNestLocalizer.text(.onboardingManagedFilesReady, status.targetRootURL.path))
+        }
+
+        let targetRepository = SwiftNestRepository(rootURL: status.targetRootURL)
+        let configCreated = try ensureOnboardingConfig(
+            at: status.configURL,
+            repository: targetRepository,
+            interactive: interactive,
+            force: parsed.contains("--force")
+        )
+
+        if configCreated {
+            print(SwiftNestLocalizer.text(.onboardingCreatedConfig, status.configURL.path))
+        } else {
+            print(SwiftNestLocalizer.text(.onboardingUsingExistingConfig, status.configURL.path))
+        }
+
+        let refreshedStatus = onboardingStatus(
+            starterRepository: repository,
+            targetRootURL: status.targetRootURL,
+            configURL: status.configURL
+        )
+        if refreshedStatus.stateExists && !parsed.contains("--force") {
+            let state = try targetRepository.loadState()
+            printOnboardingAlreadyCompletedSummary(state: state, repository: targetRepository)
+            return
+        }
+
+        let config = try HarnessDocumentLoader.loadObject(at: refreshedStatus.configURL)
+        let profileName = try resolveOnboardingProfile(parsed: parsed, repository: targetRepository, interactive: interactive)
+        let profile = try HarnessDocumentLoader.loadObject(at: targetRepository.profileURL(named: profileName))
+        let defaultSkills = HarnessDocumentLoader.stringArray(profile, key: "default_skills")
+        let skills = try resolveOnboardingSkills(
+            parsed: parsed,
+            defaultSkills: defaultSkills,
+            repository: targetRepository,
+            interactive: interactive
+        )
+        let workflows = try resolveOnboardingWorkflows(
+            parsed: parsed,
+            interactive: interactive,
+            repository: targetRepository
+        )
+
+        let result = try initializeHarness(
+            config: config,
+            configURL: refreshedStatus.configURL,
+            profileName: profileName,
+            skills: skills,
+            workflows: workflows,
+            repository: targetRepository
+        )
+
+        printOnboardingCompletedSummary(result: result, repository: targetRepository, configURL: refreshedStatus.configURL)
+    }
+
+    static func initializeHarness(
+        config: [String: Any],
+        configURL: URL,
+        profileName: String,
+        skills: [String],
+        workflows: [String],
+        repository: SwiftNestRepository
+    ) throws -> SwiftNestState {
+        let context = mergedContext(
+            base: try normalizeContext(config: config, profileName: profileName),
+            extra: workflowContext(config: config, skills: skills, workflows: workflows)
+        )
+        try writeDocs(context: context, skills: skills, profileName: profileName, repository: repository)
+        let renderedWorkflows = try scaffoldWorkflowFiles(
+            config: config,
+            profileName: profileName,
+            skills: skills,
+            workflows: workflows,
+            repository: repository
+        )
+        try writeAgentsFile(
+            config: config,
+            profileName: profileName,
+            skills: skills,
+            workflows: renderedWorkflows,
+            repository: repository
+        )
+        let contextURL = try renderContextBundle(
+            profileName: profileName,
+            skills: skills,
+            workflows: renderedWorkflows,
+            repository: repository
+        )
+
+        try repository.fileManager.createDirectory(at: repository.stateDirectoryURL, withIntermediateDirectories: true)
+        let selectedProfileURL = repository.stateDirectoryURL.appendingPathComponent("selected_profile.yaml")
+        let selectedSkillsURL = repository.stateDirectoryURL.appendingPathComponent("selected_skills.txt")
+        let profileSourceURL = try repository.profileURL(named: profileName)
+        let profileText = try String(contentsOf: profileSourceURL, encoding: .utf8)
+        try profileText.write(to: selectedProfileURL, atomically: true, encoding: .utf8)
+        try (skills.joined(separator: "\n") + "\n").write(to: selectedSkillsURL, atomically: true, encoding: .utf8)
+
+        let state = SwiftNestState(
+            profile: profileName,
+            skills: skills,
+            workflows: renderedWorkflows,
+            configPath: repository.serializeStatePath(configURL),
+            contextPath: repository.serializeStatePath(contextURL)
+        )
+        try repository.saveState(state)
+        return state
+    }
+
+    static func onboardingStatus(
+        starterRepository: SwiftNestRepository,
+        targetRootURL: URL,
+        configURL: URL
+    ) -> SwiftNestOnboardingStatus {
+        let fileManager = starterRepository.fileManager
+        let resolvedTargetRoot = targetRootURL.resolvingSymlinksInPath().standardizedFileURL
+        return SwiftNestOnboardingStatus(
+            starterRootURL: starterRepository.rootURL.resolvingSymlinksInPath().standardizedFileURL,
+            targetRootURL: resolvedTargetRoot,
+            targetAlreadyManaged: SwiftNestRepository.isRepositoryRoot(resolvedTargetRoot),
+            configURL: configURL.resolvingSymlinksInPath().standardizedFileURL,
+            configExists: fileManager.fileExists(atPath: configURL.path),
+            stateExists: fileManager.fileExists(atPath: resolvedTargetRoot.appendingPathComponent(".ai-harness/state.json").path)
+        )
+    }
+
+    static func resolveOnboardingTargetURL(
+        parsed: ParsedArguments,
+        repository: SwiftNestRepository,
+        currentDirectoryURL: URL
+    ) throws -> URL {
+        if let rawTarget = parsed.value(for: "--target"), !rawTarget.isEmpty {
+            return URL(fileURLWithPath: rawTarget, isDirectory: true).standardizedFileURL
+        }
+
+        let repoRootURL = repository.rootURL.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedCurrentDirectoryURL = currentDirectoryURL.resolvingSymlinksInPath().standardizedFileURL
+        let repoPrefix = repoRootURL.path.hasSuffix("/") ? repoRootURL.path : repoRootURL.path + "/"
+
+        if resolvedCurrentDirectoryURL.path == repoRootURL.path || resolvedCurrentDirectoryURL.path.hasPrefix(repoPrefix) {
+            if repository.isStarterCheckout {
+                throw SwiftNestError(SwiftNestLocalizer.text(.onboardingStarterCheckoutRequiresTarget))
+            }
+            return repoRootURL
+        }
+
+        if SwiftNestRepository.isRepositoryRoot(resolvedCurrentDirectoryURL) {
+            return resolvedCurrentDirectoryURL
+        }
+
+        throw SwiftNestError(SwiftNestLocalizer.text(.onboardingRequiresTargetOutsideRepository))
+    }
+
+    static func resolveOnboardingConfigURL(_ rawPath: String?, targetRootURL: URL) -> URL {
+        let configPath = rawPath?.isEmpty == false ? rawPath! : "config/project.yaml"
+        return URL(fileURLWithPath: configPath, relativeTo: targetRootURL).standardizedFileURL
+    }
+
+    static func shouldRunInteractively(parsed: ParsedArguments) -> Bool {
+        !parsed.contains("--non-interactive") && standardInputIsTTY()
+    }
+
+    static func standardInputIsTTY() -> Bool {
+        isatty(fileno(stdin)) != 0
+    }
+
+    static func ensureOnboardingConfig(
+        at configURL: URL,
+        repository: SwiftNestRepository,
+        interactive: Bool,
+        force: Bool
+    ) throws -> Bool {
+        let fileManager = repository.fileManager
+        if fileManager.fileExists(atPath: configURL.path), !force {
+            return false
+        }
+
+        let defaults = inferredConfigDraft(for: repository.rootURL, fileManager: fileManager)
+        let draft = interactive ? promptForConfigDraft(defaults: defaults) : defaults
+        try fileManager.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let yaml = renderConfigYAML(from: draft)
+        try yaml.write(to: configURL, atomically: true, encoding: .utf8)
+        return true
+    }
+
+    static func inferredConfigDraft(for targetRootURL: URL, fileManager: FileManager) -> SwiftNestOnboardingConfigDraft {
+        let repoName = inferredRepositoryName(for: targetRootURL, fileManager: fileManager)
+        let inferredCommands = inferredBuildAndTestCommands(for: targetRootURL, fileManager: fileManager)
+
+        return SwiftNestOnboardingConfigDraft(
+            projectName: repoName,
+            includesWatchCompanion: false,
+            uiFramework: "SwiftUI",
+            architectureStyle: "MVVM with Repository pattern",
+            minIOSVersion: "iOS 17",
+            packageManager: "Swift Package Manager",
+            testFramework: "XCTest",
+            lintTools: "SwiftLint, SwiftFormat",
+            networkLayerName: "APIClient + RemoteRepository",
+            persistenceLayerName: "LocalRepository",
+            loggingSystem: "OSLog",
+            privacyRequirements: "App Privacy disclosure and least-privilege data handling",
+            preferredFileLineLimit: "300",
+            healthKitLayerName: "HealthKitManager",
+            buildCommand: inferredCommands.build,
+            testCommand: inferredCommands.test
+        )
+    }
+
+    static func inferredRepositoryName(for targetRootURL: URL, fileManager: FileManager) -> String {
+        let candidates = inferredXcodeContainerNames(for: targetRootURL, fileManager: fileManager)
+        if candidates.count == 1, let candidate = candidates.first {
+            return candidate
+        }
+        let folderName = targetRootURL.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+        return folderName.isEmpty ? "MyApp" : folderName
+    }
+
+    static func inferredBuildAndTestCommands(
+        for targetRootURL: URL,
+        fileManager: FileManager
+    ) -> (build: String, test: String) {
+        let topLevelItems = (try? fileManager.contentsOfDirectory(at: targetRootURL, includingPropertiesForKeys: nil)) ?? []
+        let workspaces = topLevelItems.filter { $0.pathExtension == "xcworkspace" }
+        let projects = topLevelItems.filter { $0.pathExtension == "xcodeproj" }
+        let hasPackageManifest = fileManager.fileExists(atPath: targetRootURL.appendingPathComponent("Package.swift").path)
+
+        if workspaces.count == 1, let workspace = workspaces.first {
+            let workspaceName = workspace.lastPathComponent
+            let scheme = workspace.deletingPathExtension().lastPathComponent
+            return (
+                "xcodebuild -workspace \(workspaceName) -scheme \(scheme) build",
+                "xcodebuild -workspace \(workspaceName) -scheme \(scheme) test"
+            )
+        }
+
+        if projects.count == 1, let project = projects.first {
+            let scheme = project.deletingPathExtension().lastPathComponent
+            return (
+                "xcodebuild -scheme \(scheme) build",
+                "xcodebuild -scheme \(scheme) test"
+            )
+        }
+
+        if hasPackageManifest {
+            return ("swift build", "swift test")
+        }
+
+        return ("", "")
+    }
+
+    static func inferredXcodeContainerNames(for targetRootURL: URL, fileManager: FileManager) -> [String] {
+        let topLevelItems = (try? fileManager.contentsOfDirectory(at: targetRootURL, includingPropertiesForKeys: nil)) ?? []
+        return topLevelItems
+            .filter { $0.pathExtension == "xcworkspace" || $0.pathExtension == "xcodeproj" }
+            .map { $0.deletingPathExtension().lastPathComponent }
+            .sorted()
+    }
+
+    static func promptForConfigDraft(defaults: SwiftNestOnboardingConfigDraft) -> SwiftNestOnboardingConfigDraft {
+        print(SwiftNestLocalizer.text(.onboardingConfigPromptHeader))
+        return SwiftNestOnboardingConfigDraft(
+            projectName: promptForTextValue(.onboardingPromptProjectName, defaultValue: defaults.projectName),
+            includesWatchCompanion: promptForBooleanValue(.onboardingPromptWatchCompanion, defaultValue: defaults.includesWatchCompanion),
+            uiFramework: promptForTextValue(.onboardingPromptUIFramework, defaultValue: defaults.uiFramework),
+            architectureStyle: promptForTextValue(.onboardingPromptArchitectureStyle, defaultValue: defaults.architectureStyle),
+            minIOSVersion: defaults.minIOSVersion,
+            packageManager: defaults.packageManager,
+            testFramework: defaults.testFramework,
+            lintTools: defaults.lintTools,
+            networkLayerName: promptForTextValue(.onboardingPromptNetworkLayerName, defaultValue: defaults.networkLayerName),
+            persistenceLayerName: promptForTextValue(.onboardingPromptPersistenceLayerName, defaultValue: defaults.persistenceLayerName),
+            loggingSystem: promptForTextValue(.onboardingPromptLoggingSystem, defaultValue: defaults.loggingSystem),
+            privacyRequirements: defaults.privacyRequirements,
+            preferredFileLineLimit: defaults.preferredFileLineLimit,
+            healthKitLayerName: defaults.healthKitLayerName,
+            buildCommand: promptForTextValue(.onboardingPromptBuildCommand, defaultValue: defaults.buildCommand, allowEmpty: true),
+            testCommand: promptForTextValue(.onboardingPromptTestCommand, defaultValue: defaults.testCommand, allowEmpty: true)
+        )
+    }
+
+    static func promptForTextValue(
+        _ labelKey: SwiftNestMessageKey,
+        defaultValue: String,
+        allowEmpty: Bool = false
+    ) -> String {
+        while true {
+            let label = SwiftNestLocalizer.text(labelKey)
+            if defaultValue.isEmpty {
+                print("\(label): ", terminator: "")
+            } else {
+                print("\(label) [\(defaultValue)]: ", terminator: "")
+            }
+            let rawValue = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if rawValue.isEmpty {
+                if allowEmpty {
+                    return defaultValue
+                }
+                return defaultValue.isEmpty ? rawValue : defaultValue
+            }
+            return rawValue
+        }
+    }
+
+    static func promptForBooleanValue(_ labelKey: SwiftNestMessageKey, defaultValue: Bool) -> Bool {
+        while true {
+            let suffix = defaultValue ? "Y/n" : "y/N"
+            print("\(SwiftNestLocalizer.text(labelKey)) [\(suffix)]: ", terminator: "")
+            let rawValue = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+            if rawValue.isEmpty {
+                return defaultValue
+            }
+            switch rawValue {
+            case "y", "yes", "예", "ㅇ":
+                return true
+            case "n", "no", "아니오", "ㄴ":
+                return false
+            default:
+                print(SwiftNestLocalizer.text(.onboardingPromptBooleanRetry))
+            }
+        }
+    }
+
+    static func renderConfigYAML(from draft: SwiftNestOnboardingConfigDraft) -> String {
+        let values = draft.asDictionary()
+        let orderedKeys = [
+            "project_name",
+            "optional_watchos_line",
+            "ui_framework",
+            "architecture_style",
+            "min_ios_version",
+            "package_manager",
+            "test_framework",
+            "lint_tools",
+            "network_layer_name",
+            "persistence_layer_name",
+            "logging_system",
+            "privacy_requirements",
+            "preferred_file_line_limit",
+            "healthkit_layer_name",
+            "build_command",
+            "test_command",
+        ]
+        return orderedKeys.map { key in
+            let value = values[key] ?? ""
+            return "\(key): \(yamlScalar(value))"
+        }.joined(separator: "\n") + "\n"
+    }
+
+    static func yamlScalar(_ value: String) -> String {
+        if value.isEmpty {
+            return "\"\""
+        }
+        let needsQuotes = value.hasPrefix("#")
+            || value.contains(":")
+            || value.contains("\n")
+            || value.hasPrefix(" ")
+            || value.hasSuffix(" ")
+        if !needsQuotes {
+            return value
+        }
+        let escaped = value.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    static func resolveOnboardingProfile(
+        parsed: ParsedArguments,
+        repository: SwiftNestRepository,
+        interactive: Bool
+    ) throws -> String {
+        if let profile = parsed.value(for: "--profile"), !profile.isEmpty {
+            return profile
+        }
+        if interactive {
+            return try chooseProfileInteractively(repository: repository, defaultProfileName: defaultOnboardingProfileName)
+        }
+        if repository.fileManager.fileExists(atPath: repository.profilesURL.appendingPathComponent("\(defaultOnboardingProfileName).yaml").path) {
+            return defaultOnboardingProfileName
+        }
+        if let fallback = try repository.availableProfiles().first?.deletingPathExtension().lastPathComponent {
+            return fallback
+        }
+        return defaultOnboardingProfileName
+    }
+
+    static func resolveOnboardingSkills(
+        parsed: ParsedArguments,
+        defaultSkills: [String],
+        repository: SwiftNestRepository,
+        interactive: Bool
+    ) throws -> [String] {
+        if let rawSkills = parsed.value(for: "--skills"), !rawSkills.isEmpty {
+            return Array(Set(rawSkills.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty })).sorted()
+        }
+        if interactive {
+            return try chooseSkillsInteractively(defaultSkills: defaultSkills, repository: repository)
+        }
+        return defaultSkills.sorted()
+    }
+
+    static func resolveOnboardingWorkflows(
+        parsed: ParsedArguments,
+        interactive: Bool,
+        repository: SwiftNestRepository
+    ) throws -> [String] {
+        if let rawWorkflows = parsed.value(for: "--workflows"), !rawWorkflows.isEmpty {
+            let names = rawWorkflows
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            let validated = try validateWorkflowNames(names)
+            let merged = Set(defaultWorkflowNames).union(validated)
+            return orderedWorkflowDefinitions().map(\.name).filter { merged.contains($0) }
+        }
+        if interactive {
+            return try chooseWorkflowsInteractively(defaultWorkflows: defaultWorkflowNames)
+        }
+        return defaultWorkflowNames
+    }
+
+    static func chooseWorkflowsInteractively(defaultWorkflows: [String]) throws -> [String] {
+        print(SwiftNestLocalizer.text(.availableWorkflowsHeader))
+        let definitions = orderedWorkflowDefinitions()
+        for (index, workflow) in definitions.enumerated() {
+            let kind = workflow.isDefault
+                ? SwiftNestLocalizer.text(.workflowKindDefault)
+                : SwiftNestLocalizer.text(.workflowKindOptional)
+            let enabledByDefault = defaultWorkflows.contains(workflow.name)
+            let mark = enabledByDefault ? "*" : " "
+            print(String(format: "  %2d. [%@] %@ (%@) — %@", index + 1, mark, workflow.name, kind, workflow.runtimeDescription()))
+        }
+        print(SwiftNestLocalizer.text(.selectWorkflowsPrompt), terminator: "")
+        let raw = readLine()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if raw.isEmpty {
+            return defaultWorkflows
+        }
+        var chosen: [String] = []
+        for token in raw.split(separator: ",") {
+            let trimmed = token.trimmingCharacters(in: .whitespaces)
+            guard let number = Int(trimmed) else {
+                throw SwiftNestError(SwiftNestLocalizer.text(.invalidSelection, trimmed))
+            }
+            guard definitions.indices.contains(number - 1) else {
+                throw SwiftNestError(SwiftNestLocalizer.text(.selectionOutOfRange, trimmed))
+            }
+            chosen.append(definitions[number - 1].name)
+        }
+        let merged = Set(defaultWorkflowNames).union(chosen)
+        return definitions.map(\.name).filter { merged.contains($0) }
+    }
+
+    static func printOnboardingAlreadyCompletedSummary(state: SwiftNestState, repository: SwiftNestRepository) {
+        print(SwiftNestLocalizer.text(.onboardingAlreadyCompleted, repository.rootURL.path))
+        print(SwiftNestLocalizer.text(.onboardingCurrentProfile, state.profile))
+        print(SwiftNestLocalizer.text(.onboardingCurrentSkills, state.skills.joined(separator: ", ")))
+        print(SwiftNestLocalizer.text(.onboardingCurrentWorkflows, normalizedWorkflowNames(state.workflows).joined(separator: ", ")))
+        print(SwiftNestLocalizer.text(.onboardingUseForceToRerun))
+    }
+
+    static func printOnboardingCompletedSummary(
+        result: SwiftNestState,
+        repository: SwiftNestRepository,
+        configURL: URL
+    ) {
+        let contextURL = repository.resolveStatePath(result.contextPath)
+        print(SwiftNestLocalizer.text(.onboardingCompleted, repository.rootURL.path))
+        print(SwiftNestLocalizer.text(.onboardingConfigReady, configURL.path))
+        print(SwiftNestLocalizer.text(.onboardingCurrentProfile, result.profile))
+        print(SwiftNestLocalizer.text(.onboardingCurrentSkills, result.skills.joined(separator: ", ")))
+        print(SwiftNestLocalizer.text(.onboardingCurrentWorkflows, normalizedWorkflowNames(result.workflows).joined(separator: ", ")))
+        print(SwiftNestLocalizer.text(.onboardingGeneratedFilesHeader))
+        print("  - AGENTS.md")
+        print("  - Docs/AI_RULES.md")
+        print("  - Docs/AI_WORKFLOWS.md")
+        print("  - Docs/AI_SKILLS/*")
+        print("  - .ai-harness/state.json")
+        print("  - .ai-harness/rendered_context.md")
+        print(SwiftNestLocalizer.text(.onboardingHowAgentsUseThisHeader))
+        print(SwiftNestLocalizer.text(.onboardingHowAgentsUseThisLine1))
+        print(SwiftNestLocalizer.text(.onboardingHowAgentsUseThisLine2))
+        print(SwiftNestLocalizer.text(.onboardingNextStepsHeader))
+        print(SwiftNestLocalizer.text(.onboardingNextStepReviewConfig, configURL.path))
+        print(SwiftNestLocalizer.text(.onboardingNextStepReviewAgents))
+        print(SwiftNestLocalizer.text(.onboardingNextStepAgentRoot, repository.rootURL.path))
+        print(SwiftNestLocalizer.text(.renderedContext, contextURL.path))
+    }
+
+    static func skillSummary(named skill: String, repository: SwiftNestRepository) -> String {
+        let candidates = [
+            repository.rootURL.appendingPathComponent("Docs/AI_SKILLS/\(skill).md"),
+            repository.templatesURL.appendingPathComponent("Docs/AI_SKILLS/\(skill).md"),
+        ]
+        for candidate in candidates where repository.fileManager.fileExists(atPath: candidate.path) {
+            if let contents = try? String(contentsOf: candidate, encoding: .utf8) {
+                let lines = contents.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+                if let summary = lines.first(where: { $0.hasPrefix("Apply this skill whenever") || $0.hasPrefix("Use this skill whenever") || $0.hasPrefix("Apply this skill") }), !summary.isEmpty {
+                    return summary
+                }
+            }
+        }
+        return SwiftNestLocalizer.text(.onboardingSkillSummaryFallback)
+    }
+}

--- a/tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift
+++ b/tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift
@@ -95,7 +95,8 @@ final class SwiftNestCLITests: XCTestCase {
 
     func testLocalizedUsageAndPromptStringsAreAvailableInKorean() {
         XCTAssertTrue(SwiftNestLocalizer.text(.usageTopLevel, language: .ko).contains("사용법"))
-        XCTAssertTrue(SwiftNestLocalizer.text(.chooseProfileNumberPrompt, language: .ko).contains("프로필 번호"))
+        XCTAssertTrue(SwiftNestLocalizer.text(.usageTopLevel, language: .ko).contains("onboard"))
+        XCTAssertTrue(SwiftNestLocalizer.text(.chooseProfileNumberPrompt, language: .ko, "2").contains("프로필 번호"))
     }
 
     func testWorkflowRuntimeDescriptionIsLocalized() throws {
@@ -147,6 +148,93 @@ final class SwiftNestCLITests: XCTestCase {
         )
     }
 
+    func testOnboardCreatesConfigDocsAndStateInTargetRepository() throws {
+        let fileManager = FileManager.default
+        let starterRoot = try makeRepositoryFixture()
+        let targetRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("SampleApp-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: targetRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(
+            at: targetRoot.appendingPathComponent("SampleApp.xcworkspace", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let parsed = ParsedArguments(
+            values: [
+                "--target": targetRoot.path,
+                "--workflows": "networking,review",
+            ],
+            flags: ["--non-interactive"],
+            positionals: []
+        )
+
+        try SwiftNestCLI.runOnboard(parsed: parsed, repository: SwiftNestRepository(rootURL: starterRoot))
+
+        XCTAssertTrue(fileManager.fileExists(atPath: targetRoot.appendingPathComponent("swiftnest").path))
+        XCTAssertTrue(fileManager.fileExists(atPath: targetRoot.appendingPathComponent("config/project.yaml").path))
+        XCTAssertTrue(fileManager.fileExists(atPath: targetRoot.appendingPathComponent("AGENTS.md").path))
+        XCTAssertTrue(fileManager.fileExists(atPath: targetRoot.appendingPathComponent("Docs/AI_RULES.md").path))
+        XCTAssertTrue(fileManager.fileExists(atPath: targetRoot.appendingPathComponent(".ai-harness/state.json").path))
+        XCTAssertTrue(fileManager.fileExists(atPath: targetRoot.appendingPathComponent(".ai-harness/workflows/networking.md").path))
+        XCTAssertTrue(fileManager.fileExists(atPath: targetRoot.appendingPathComponent(".ai-harness/workflows/review.md").path))
+
+        let configText = try String(contentsOf: targetRoot.appendingPathComponent("config/project.yaml"), encoding: .utf8)
+        XCTAssertTrue(configText.contains("project_name: SampleApp"))
+        XCTAssertTrue(configText.contains("build_command: xcodebuild -workspace SampleApp.xcworkspace -scheme SampleApp build"))
+
+        let state = try JSONDecoder().decode(
+            SwiftNestState.self,
+            from: Data(contentsOf: targetRoot.appendingPathComponent(".ai-harness/state.json"))
+        )
+        XCTAssertEqual(state.profile, "intermediate")
+        XCTAssertEqual(state.skills, ["concurrency-rules", "ios-architecture", "networking-rules", "swiftui-rules", "testing-rules"])
+        XCTAssertEqual(state.workflows, ["add-feature", "fix-bug", "refactor", "build", "networking", "review"])
+    }
+
+    func testOnboardRequiresTargetWhenOutsideRepositoryContext() throws {
+        let repository = SwiftNestRepository(rootURL: try makeRepositoryFixture())
+        let outsideURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: outsideURL, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(
+            try SwiftNestCLI.resolveOnboardingTargetURL(
+                parsed: ParsedArguments(values: [:], flags: [], positionals: []),
+                repository: repository,
+                currentDirectoryURL: outsideURL
+            )
+        ) { error in
+            guard let swiftNestError = error as? SwiftNestError else {
+                XCTFail("Expected SwiftNestError")
+                return
+            }
+            XCTAssertEqual(
+                swiftNestError.message,
+                "onboard requires --target <path> when you are not already inside a SwiftNest-managed repository."
+            )
+        }
+    }
+
+    func testOnboardRequiresTargetFromStarterCheckout() throws {
+        let repository = SwiftNestRepository(rootURL: try makeRepositoryFixture(includeStarterOnlyPaths: true))
+
+        XCTAssertThrowsError(
+            try SwiftNestCLI.resolveOnboardingTargetURL(
+                parsed: ParsedArguments(values: [:], flags: [], positionals: []),
+                repository: repository,
+                currentDirectoryURL: repository.rootURL
+            )
+        ) { error in
+            guard let swiftNestError = error as? SwiftNestError else {
+                XCTFail("Expected SwiftNestError")
+                return
+            }
+            XCTAssertEqual(
+                swiftNestError.message,
+                "Running onboard from the SwiftNest starter checkout requires --target <path> so the target app repository is updated instead of the starter itself."
+            )
+        }
+    }
+
     func testRootWrapperUsesKoreanErrorWhenSwiftIsMissing() throws {
         let wrapperURL = repositoryRootURL().appendingPathComponent("swiftnest")
         let emptyBinDirectory = FileManager.default.temporaryDirectory
@@ -175,7 +263,7 @@ final class SwiftNestCLITests: XCTestCase {
         XCTAssertTrue(stderr.contains("오류: macOS에서 SwiftNest CLI를 빌드하려면 swift가 필요합니다."))
     }
 
-    private func makeRepositoryFixture() throws -> URL {
+    private func makeRepositoryFixture(includeStarterOnlyPaths: Bool = false) throws -> URL {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -195,6 +283,12 @@ final class SwiftNestCLITests: XCTestCase {
                 withIntermediateDirectories: true
             )
         }
+        if includeStarterOnlyPaths {
+            try fileManager.createDirectory(
+                at: root.appendingPathComponent("packaging/homebrew", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
 
         let filePaths = [
             "Makefile",
@@ -208,18 +302,29 @@ final class SwiftNestCLITests: XCTestCase {
             "templates/Docs/AI_PROMPT_ENTRY.md",
             "templates/Docs/AI_RULES.md",
             "templates/Docs/AI_WORKFLOWS.md",
+            "templates/Docs/AI_SKILLS/concurrency-rules.md",
             "templates/Docs/AI_SKILLS/ios-architecture.md",
+            "templates/Docs/AI_SKILLS/networking-rules.md",
+            "templates/Docs/AI_SKILLS/swiftui-rules.md",
+            "templates/Docs/AI_SKILLS/testing-rules.md",
             "templates/Workflows/add-feature.md",
             "templates/Workflows/build.md",
             "templates/Workflows/fix-bug.md",
+            "templates/Workflows/networking.md",
             "templates/Workflows/refactor.md",
+            "templates/Workflows/review.md",
             "tools/swiftnest-cli/Package.swift",
             "tools/swiftnest-cli/Sources/SimpleDocumentLoader.swift",
             "tools/swiftnest-cli/Sources/SwiftNestCLI.swift",
+            "tools/swiftnest-cli/Sources/SwiftNestLocalization.swift",
+            "tools/swiftnest-cli/Sources/SwiftNestOnboarding.swift",
             "tools/swiftnest-cli/Sources/WorkflowSupport.swift",
             "tools/swiftnest-cli/Sources/main.swift",
             "tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift",
         ]
+        let extendedFilePaths = includeStarterOnlyPaths
+            ? filePaths + ["packaging/homebrew/swiftnest.rb.template"]
+            : filePaths
         let fileContents: [String: String] = [
             "profiles/advanced.yaml": """
             name: advanced
@@ -241,10 +346,39 @@ final class SwiftNestCLITests: XCTestCase {
             description_ko: 제품 개발에 균형 있게 맞춘 구성입니다.
             default_skills:
               - ios-architecture
+              - swiftui-rules
+              - concurrency-rules
+              - networking-rules
+              - testing-rules
+            """,
+            "templates/Docs/AI_SKILLS/concurrency-rules.md": """
+            # Concurrency Rules
+
+            Apply this skill whenever async work, task orchestration, cancellation, or actor correctness is involved.
+            """,
+            "templates/Docs/AI_SKILLS/ios-architecture.md": """
+            # iOS Architecture Rules
+
+            Apply this skill whenever the task touches app structure, screen composition, or responsibility boundaries.
+            """,
+            "templates/Docs/AI_SKILLS/networking-rules.md": """
+            # Networking Rules
+
+            Apply this skill whenever API calls, request/response modeling, retries, or remote sync behavior are involved.
+            """,
+            "templates/Docs/AI_SKILLS/swiftui-rules.md": """
+            # SwiftUI Rules
+
+            Apply this skill whenever the task touches SwiftUI screens or UI state.
+            """,
+            "templates/Docs/AI_SKILLS/testing-rules.md": """
+            # Testing Rules
+
+            Apply this skill whenever logic changes are introduced.
             """,
         ]
 
-        for filePath in filePaths {
+        for filePath in extendedFilePaths {
             let destinationURL = root.appendingPathComponent(filePath)
             try fileManager.createDirectory(at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             let contents = fileContents[filePath] ?? "fixture"


### PR DESCRIPTION
## Summary
- add a top-level `onboard` command that installs SwiftNest, scaffolds `config/project.yaml`, initializes docs/state, and explains the agent handoff
- improve interactive and non-interactive setup with inferred config defaults, workflow selection, and starter-checkout safety checks
- update Homebrew packaging/docs/tests so the bootstrap flow and verification use `onboard` as the primary entrypoint

## Testing
- swift test --package-path tools/swiftnest-cli
- ./swiftnest --lang ko --help
- ./swiftnest --lang ko onboard --target <temp repo> --workflows networking,review --non-interactive
- ruby -c packaging/homebrew/swiftnest.rb.template
- git diff --check