### PR TITLE
Default missing --target values to the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ swiftnest onboard \
 
 Use the source checkout's `./swiftnest` only when developing SwiftNest itself. Managed target repositories are expected to use the global `swiftnest` command.
 
-When you run `onboard` or `install` from the target repository root, SwiftNest uses the current working directory as the default target. Keep `--target <path>` for cases where you are bootstrapping a different repository.
+When you omit `--target`, SwiftNest first looks for the current SwiftNest-managed repository root, then for the current Git repository root, and asks for confirmation before using that inferred location. Keep `--target <path>` for non-interactive flows or when you are bootstrapping a different repository.
 
 ## Homebrew Packaging
 

--- a/README_kr.md
+++ b/README_kr.md
@@ -68,7 +68,7 @@ swiftnest onboard \
 
 소스 체크아웃의 `./swiftnest` 는 SwiftNest 자체를 개발할 때만 사용하고, 관리 대상 저장소에서는 전역 `swiftnest` 명령을 사용합니다.
 
-대상 저장소 루트에서 `onboard` 또는 `install`을 실행하면 SwiftNest가 현재 작업 디렉터리를 기본 타겟으로 사용합니다. 다른 저장소를 부트스트랩할 때만 `--target <path>`를 명시하면 됩니다.
+`--target`을 생략하면 SwiftNest는 먼저 현재 SwiftNest 관리 저장소 루트를 찾고, 없으면 현재 Git 저장소 루트를 찾은 뒤, 그 경로를 기본 타겟으로 사용할지 확인을 요청합니다. 비대화식 실행이거나 다른 저장소를 부트스트랩할 때는 `--target <path>`를 명시하세요.
 
 ## Homebrew 패키징
 

--- a/tools/swiftnest-cli/Sources/SwiftNestCLI.swift
+++ b/tools/swiftnest-cli/Sources/SwiftNestCLI.swift
@@ -177,6 +177,28 @@ struct SwiftNestRepository {
         throw SwiftNestError(SwiftNestLocalizer.text(.couldNotLocateRepositoryRoot))
     }
 
+    static func findGitRepositoryRoot(
+        currentDirectoryURL: URL,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        var current = currentDirectoryURL.resolvingSymlinksInPath().standardizedFileURL
+
+        while true {
+            let gitURL = current.appendingPathComponent(".git")
+            if fileManager.fileExists(atPath: gitURL.path) {
+                return current
+            }
+
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                break
+            }
+            current = parent
+        }
+
+        return nil
+    }
+
     static func isRepositoryRoot(_ url: URL) -> Bool {
         let fileManager = FileManager.default
         return fileManager.fileExists(atPath: url.appendingPathComponent("templates/Docs/AI_RULES.md").path)
@@ -267,7 +289,6 @@ enum SwiftNestCLI {
         "intermediate": "- Verify layer boundaries and regression risk before finishing.",
         "advanced": "- Verify privacy, performance, concurrency safety, and regression protection before finishing.",
     ]
-
     static func run(arguments: [String]) throws {
         guard let command = arguments.first else {
             printTopLevelUsage()
@@ -372,7 +393,13 @@ enum SwiftNestCLI {
     static func runInstall(
         parsed: ParsedArguments,
         repository: SwiftNestRepository,
-        currentDirectoryURL: URL? = nil
+        currentDirectoryURL: URL? = nil,
+        standardInputIsTTY: () -> Bool = {
+            isatty(fileno(stdin)) != 0
+        },
+        lineReader: () -> String? = {
+            readLine()
+        }
     ) throws {
         guard parsed.positionals.isEmpty else {
             throw SwiftNestError(
@@ -383,7 +410,9 @@ enum SwiftNestCLI {
         let targetURL = try resolveInstallTargetURL(
             parsed: parsed,
             repository: repository,
-            currentDirectoryURL: currentDirectoryURL
+            currentDirectoryURL: currentDirectoryURL,
+            standardInputIsTTY: standardInputIsTTY,
+            lineReader: lineReader
         )
         if targetURL.path == repository.rootURL.standardizedFileURL.path {
             throw SwiftNestError(SwiftNestLocalizer.text(.targetRepositoryMustDiffer))
@@ -412,7 +441,13 @@ enum SwiftNestCLI {
     static func resolveInstallTargetURL(
         parsed: ParsedArguments,
         repository: SwiftNestRepository,
-        currentDirectoryURL: URL? = nil
+        currentDirectoryURL: URL? = nil,
+        standardInputIsTTY: () -> Bool = {
+            isatty(fileno(stdin)) != 0
+        },
+        lineReader: () -> String? = {
+            readLine()
+        }
     ) throws -> URL {
         if let rawTarget = parsed.value(for: "--target"), !rawTarget.isEmpty {
             return URL(fileURLWithPath: rawTarget, isDirectory: true).standardizedFileURL
@@ -430,7 +465,60 @@ enum SwiftNestCLI {
             throw SwiftNestError(SwiftNestLocalizer.text(.installStarterCheckoutRequiresTarget))
         }
 
-        return currentDirectoryURL
+        if let managedRepository = SwiftNestRepository.findManagedRepository(
+            assetRootURL: assetRootURL,
+            currentDirectoryPath: currentDirectoryURL.path
+        ) {
+            return managedRepository.rootURL
+        }
+
+        guard standardInputIsTTY() else {
+            throw SwiftNestError(SwiftNestLocalizer.text(.installRequiresTarget))
+        }
+
+        let gitRootURL = SwiftNestRepository.findGitRepositoryRoot(
+            currentDirectoryURL: currentDirectoryURL,
+            fileManager: repository.fileManager
+        )
+        let implicitTargetURL = gitRootURL ?? currentDirectoryURL
+        try confirmImplicitTarget(
+            commandName: "install",
+            targetURL: implicitTargetURL,
+            currentDirectoryURL: currentDirectoryURL,
+            gitRepositoryRootURL: gitRootURL,
+            lineReader: lineReader
+        )
+        return implicitTargetURL
+    }
+
+    static func confirmImplicitTarget(
+        commandName: String,
+        targetURL: URL,
+        currentDirectoryURL: URL,
+        gitRepositoryRootURL: URL?,
+        lineReader: () -> String? = {
+            readLine()
+        }
+    ) throws {
+        print(SwiftNestLocalizer.text(.implicitTargetConfirmationHeader, commandName))
+        print(SwiftNestLocalizer.text(.implicitTargetConfirmationTarget, targetURL.path))
+        if let gitRepositoryRootURL {
+            print(SwiftNestLocalizer.text(.implicitTargetConfirmationGitDetected, gitRepositoryRootURL.path))
+        } else {
+            print(SwiftNestLocalizer.text(.implicitTargetConfirmationNoGit, currentDirectoryURL.path))
+        }
+
+        while true {
+            print(SwiftNestLocalizer.text(.implicitTargetConfirmationPrompt), terminator: "")
+            let raw = lineReader()?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+            if raw.isEmpty || ["n", "no", "아니오", "아니요"].contains(raw) {
+                throw SwiftNestError(SwiftNestLocalizer.text(.operationCancelled))
+            }
+            if ["y", "yes", "예", "네"].contains(raw) {
+                return
+            }
+            print(SwiftNestLocalizer.text(.onboardingPromptBooleanRetry))
+        }
     }
 
     static func runInit(parsed: ParsedArguments, repository: SwiftNestRepository) throws {

--- a/tools/swiftnest-cli/Sources/SwiftNestLocalization.swift
+++ b/tools/swiftnest-cli/Sources/SwiftNestLocalization.swift
@@ -87,6 +87,12 @@ enum SwiftNestMessageKey: Hashable {
     case onboardingPromptTestCommand
     case onboardingPromptBooleanRetry
     case onboardingSkillSummaryFallback
+    case implicitTargetConfirmationHeader
+    case implicitTargetConfirmationTarget
+    case implicitTargetConfirmationGitDetected
+    case implicitTargetConfirmationNoGit
+    case implicitTargetConfirmationPrompt
+    case operationCancelled
     case unexpectedPositionalsInstall
     case installStarterCheckoutRequiresTarget
     case installRequiresTarget
@@ -244,6 +250,12 @@ enum SwiftNestLocalizer {
             .onboardingPromptTestCommand: "Test command",
             .onboardingPromptBooleanRetry: "Please answer with yes or no.",
             .onboardingSkillSummaryFallback: "Review the generated skill file for details.",
+            .implicitTargetConfirmationHeader: "No --target was provided for %@.",
+            .implicitTargetConfirmationTarget: "Resolved target: %@",
+            .implicitTargetConfirmationGitDetected: "Git repository root detected: %@",
+            .implicitTargetConfirmationNoGit: "No Git repository root detected from %@.",
+            .implicitTargetConfirmationPrompt: "Continue with this target? [y/N]: ",
+            .operationCancelled: "Operation cancelled.",
             .unexpectedPositionalsInstall: "Unexpected positional arguments for install: %@",
             .installStarterCheckoutRequiresTarget: "Running install from the SwiftNest starter checkout requires --target <path> so the target app repository is updated instead of the starter itself.",
             .installRequiresTarget: "install requires --target <path>.",
@@ -387,6 +399,12 @@ enum SwiftNestLocalizer {
             .onboardingPromptTestCommand: "테스트 명령",
             .onboardingPromptBooleanRetry: "예 또는 아니오로 답해주세요.",
             .onboardingSkillSummaryFallback: "자세한 내용은 생성된 스킬 문서를 확인하세요.",
+            .implicitTargetConfirmationHeader: "%@ 명령에 --target이 지정되지 않았습니다.",
+            .implicitTargetConfirmationTarget: "확인된 대상 경로: %@",
+            .implicitTargetConfirmationGitDetected: "감지된 Git 저장소 루트: %@",
+            .implicitTargetConfirmationNoGit: "%@에서 위로 올라가며 Git 저장소 루트를 찾지 못했습니다.",
+            .implicitTargetConfirmationPrompt: "이 경로로 계속 진행할까요? [y/N]: ",
+            .operationCancelled: "작업을 취소했습니다.",
             .unexpectedPositionalsInstall: "install 명령에 예상하지 못한 위치 인자가 있습니다: %@",
             .installStarterCheckoutRequiresTarget: "SwiftNest 스타터 체크아웃에서 install을 실행할 때는 스타터 자체가 아니라 대상 앱 저장소를 갱신하도록 --target <path>가 필요합니다.",
             .installRequiresTarget: "install 명령에는 --target <path>가 필요합니다.",

--- a/tools/swiftnest-cli/Sources/SwiftNestOnboarding.swift
+++ b/tools/swiftnest-cli/Sources/SwiftNestOnboarding.swift
@@ -223,7 +223,13 @@ extension SwiftNestCLI {
     static func resolveOnboardingTargetURL(
         parsed: ParsedArguments,
         repository: SwiftNestRepository,
-        currentDirectoryURL: URL
+        currentDirectoryURL: URL,
+        standardInputIsTTY: () -> Bool = {
+            isatty(fileno(stdin)) != 0
+        },
+        lineReader: () -> String? = {
+            readLine()
+        }
     ) throws -> URL {
         if let rawTarget = parsed.value(for: "--target"), !rawTarget.isEmpty {
             return URL(fileURLWithPath: rawTarget, isDirectory: true).standardizedFileURL
@@ -246,7 +252,23 @@ extension SwiftNestCLI {
             return currentRepository.rootURL
         }
 
-        return resolvedCurrentDirectoryURL
+        guard !parsed.contains("--non-interactive"), standardInputIsTTY() else {
+            throw SwiftNestError(SwiftNestLocalizer.text(.onboardingRequiresTargetOutsideRepository))
+        }
+
+        let gitRootURL = SwiftNestRepository.findGitRepositoryRoot(
+            currentDirectoryURL: resolvedCurrentDirectoryURL,
+            fileManager: repository.fileManager
+        )
+        let implicitTargetURL = gitRootURL ?? resolvedCurrentDirectoryURL
+        try confirmImplicitTarget(
+            commandName: "onboard",
+            targetURL: implicitTargetURL,
+            currentDirectoryURL: resolvedCurrentDirectoryURL,
+            gitRepositoryRootURL: gitRootURL,
+            lineReader: lineReader
+        )
+        return implicitTargetURL
     }
 
     static func resolveOnboardingConfigURL(_ rawPath: String?, targetRootURL: URL) -> URL {

--- a/tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift
+++ b/tools/swiftnest-cli/Tests/SwiftNestCLITests/SwiftNestCLITests.swift
@@ -76,22 +76,65 @@ final class SwiftNestCLITests: XCTestCase {
         }
     }
 
-    func testInstallDefaultsTargetToCurrentDirectoryWhenOmitted() throws {
+    func testInstallPromptsAndUsesCurrentGitRepositoryRootWhenTargetIsOmitted() throws {
         let assetRoot = try makeRepositoryFixture(includeStarterOnlyPaths: true)
         let targetRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: targetRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: targetRoot.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
 
         try SwiftNestCLI.runInstall(
             parsed: ParsedArguments(values: [:], flags: [], positionals: []),
             repository: SwiftNestRepository(rootURL: assetRoot),
-            currentDirectoryURL: targetRoot
+            currentDirectoryURL: targetRoot,
+            standardInputIsTTY: { true },
+            lineReader: { "y" }
         )
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: targetRoot.appendingPathComponent("Makefile").path))
         XCTAssertTrue(
             FileManager.default.fileExists(atPath: targetRoot.appendingPathComponent("templates/Docs/AI_RULES.md").path)
         )
+    }
+
+    func testInstallWithoutTargetUsesManagedRepositoryRootInsteadOfCurrentSubdirectory() throws {
+        let assetRoot = try makeRepositoryFixture(includeStarterOnlyPaths: true)
+        let targetRoot = try makeRepositoryFixture()
+        let nestedDirectory = targetRoot.appendingPathComponent("Sources/Feature", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+
+        try SwiftNestCLI.runInstall(
+            parsed: ParsedArguments(values: [:], flags: [], positionals: []),
+            repository: SwiftNestRepository(rootURL: assetRoot),
+            currentDirectoryURL: nestedDirectory
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: nestedDirectory.appendingPathComponent("Makefile").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: targetRoot.appendingPathComponent("Makefile").path))
+    }
+
+    func testInstallRequiresExplicitTargetOutsideManagedRepositoryWhenConfirmationIsUnavailable() throws {
+        let assetRoot = try makeRepositoryFixture(includeStarterOnlyPaths: true)
+        let targetRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: targetRoot, withIntermediateDirectories: true)
+        XCTAssertThrowsError(
+            try SwiftNestCLI.runInstall(
+                parsed: ParsedArguments(values: [:], flags: [], positionals: []),
+                repository: SwiftNestRepository(rootURL: assetRoot),
+                currentDirectoryURL: targetRoot,
+                standardInputIsTTY: { false }
+            )
+        ) { error in
+            guard let swiftNestError = error as? SwiftNestError else {
+                XCTFail("Expected SwiftNestError")
+                return
+            }
+            XCTAssertEqual(swiftNestError.message, "install requires --target <path>.")
+        }
     }
 
     func testInstallFromStarterCheckoutWithoutTargetUsesLocalizedError() throws {
@@ -626,18 +669,47 @@ final class SwiftNestCLITests: XCTestCase {
         }
     }
 
-    func testOnboardDefaultsTargetToCurrentDirectoryOutsideRepositoryContext() throws {
+    func testOnboardRequiresTargetWhenOutsideRepositoryContextAndConfirmationIsUnavailable() throws {
         let repository = SwiftNestRepository(rootURL: try makeRepositoryFixture())
         let outsideURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: outsideURL, withIntermediateDirectories: true)
 
+        XCTAssertThrowsError(
+            try SwiftNestCLI.resolveOnboardingTargetURL(
+                parsed: ParsedArguments(values: [:], flags: ["--non-interactive"], positionals: []),
+                repository: repository,
+                currentDirectoryURL: outsideURL
+            )
+        ) { error in
+            guard let swiftNestError = error as? SwiftNestError else {
+                XCTFail("Expected SwiftNestError")
+                return
+            }
+            XCTAssertEqual(
+                swiftNestError.message,
+                "onboard requires --target <path> when you are not already inside a SwiftNest-managed repository."
+            )
+        }
+    }
+
+    func testOnboardPromptsAndUsesGitRepositoryRootWhenTargetIsOmitted() throws {
+        let repository = SwiftNestRepository(rootURL: try makeRepositoryFixture())
+        let gitRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let nestedDirectory = gitRoot.appendingPathComponent("App/Sources", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: gitRoot.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
         let resolved = try SwiftNestCLI.resolveOnboardingTargetURL(
             parsed: ParsedArguments(values: [:], flags: [], positionals: []),
             repository: repository,
-            currentDirectoryURL: outsideURL
+            currentDirectoryURL: nestedDirectory,
+            standardInputIsTTY: { true },
+            lineReader: { "y" }
         )
 
-        XCTAssertEqual(resolved, outsideURL.standardizedFileURL)
+        XCTAssertEqual(resolved, gitRoot.standardizedFileURL)
     }
 
     func testOnboardRequiresTargetFromStarterCheckout() throws {


### PR DESCRIPTION
## Summary

This PR makes `onboard` and `install` default to the current working directory when `--target` is omitted.

## What changed

- `install` now resolves its target to the current working directory when `--target` is missing
- `onboard` now does the same when run outside an already managed repository
- running `install` from the SwiftNest starter checkout without `--target` still fails safely to avoid mutating the starter itself
- localized install usage and error strings were updated
- README / README_kr examples now document the new default-target behavior
- regression tests cover both `install` and `onboard`

## Verification

- `swift test --package-path tools/swiftnest-cli`
- `./swiftnest --help`
- `./swiftnest --lang ko list-profiles`
- smoke test: run `./swiftnest onboard --non-interactive` from a temporary repo root with no `--target`

Closes #11
