### PR TITLE
Migrate Homebrew tap from homebrew-swiftnest to homebrew-tap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ When a feature affects starter contents or Homebrew-visible behavior, finish the
 2. Create and push a new Git tag from `swift-nest`.
 3. Download the matching GitHub tag archive and compute its SHA256.
 4. Render `packaging/homebrew/swiftnest.rb.template` into the tap repository as `Formula/swiftnest.rb`.
-5. Commit and push the updated formula in `oozoofrog/homebrew-swiftnest` (or the active tap repo).
+5. Commit and push the updated formula in `oozoofrog/homebrew-tap`.
 6. Verify with `brew install swiftnest`, `brew test swiftnest`, and at least one smoke test such as `swiftnest onboard --target <repo>` or `swiftnest --lang ko list-profiles`.
 
 ## Completion Expectations

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ When you omit `--target`, SwiftNest first looks for the current SwiftNest-manage
 
 ## Homebrew Packaging
 
-SwiftNest ships Homebrew packaging assets under `packaging/homebrew/` for a separate tap repository such as `oozoofrog/homebrew-swiftnest`.
+SwiftNest ships Homebrew packaging assets under `packaging/homebrew/` for a separate tap repository such as `oozoofrog/homebrew-tap`.
 
 Recommended release flow:
 
@@ -92,7 +92,7 @@ For the end-to-end release sequence to run after a feature lands on `main`, foll
 Once the tap is published, the intended install flow is:
 
 ```bash
-brew tap oozoofrog/swiftnest https://github.com/oozoofrog/homebrew-swiftnest
+brew tap oozoofrog/tap https://github.com/oozoofrog/homebrew-tap
 brew install swiftnest
 swiftnest onboard --target /path/to/current-ios-repo
 ```

--- a/README_kr.md
+++ b/README_kr.md
@@ -77,7 +77,7 @@ swiftnest onboard \
 
 ## Homebrew 패키징
 
-SwiftNest는 별도 tap 저장소(예: `oozoofrog/homebrew-swiftnest`)에서 사용할 Homebrew 패키징 자산을 `packaging/homebrew/` 아래에 함께 제공합니다.
+SwiftNest는 별도 tap 저장소(예: `oozoofrog/homebrew-tap`)에서 사용할 Homebrew 패키징 자산을 `packaging/homebrew/` 아래에 함께 제공합니다.
 
 권장 릴리즈 흐름:
 
@@ -92,7 +92,7 @@ SwiftNest는 별도 tap 저장소(예: `oozoofrog/homebrew-swiftnest`)에서 사
 tap 이 공개된 이후 기대하는 설치 흐름은 아래와 같습니다.
 
 ```bash
-brew tap oozoofrog/swiftnest https://github.com/oozoofrog/homebrew-swiftnest
+brew tap oozoofrog/tap https://github.com/oozoofrog/homebrew-tap
 brew install swiftnest
 swiftnest onboard --target /path/to/current-ios-repo
 ```

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -16,7 +16,7 @@ Release the Homebrew formula in this order:
 1. Create and push a new Git tag from `swift-nest`.
 2. Download the matching tag archive from GitHub.
 3. Compute the archive SHA256.
-4. Render the formula into the tap repository, typically `oozoofrog/homebrew-swiftnest`.
+4. Render the formula into the tap repository, typically `oozoofrog/homebrew-tap`.
 
 For the feature-to-release handoff sequence after work lands on `main`, see the repository `AGENTS.md`.
 
@@ -24,7 +24,7 @@ For the feature-to-release handoff sequence after work lands on `main`, see the 
    ./packaging/homebrew/render_formula.sh \
      --tag v0.1.3 \
      --archive /tmp/swift-nest-v0.1.3.tar.gz \
-     --output /path/to/homebrew-swiftnest/Formula/swiftnest.rb
+     --output /path/to/homebrew-tap/Formula/swiftnest.rb
    ```
 
    or
@@ -33,14 +33,14 @@ For the feature-to-release handoff sequence after work lands on `main`, see the 
    make render-homebrew-formula \
      RELEASE_TAG=v0.1.3 \
      RELEASE_ARCHIVE=/tmp/swift-nest-v0.1.3.tar.gz \
-     FORMULA_OUTPUT=/path/to/homebrew-swiftnest/Formula/swiftnest.rb
+     FORMULA_OUTPUT=/path/to/homebrew-tap/Formula/swiftnest.rb
    ```
 
 5. Commit the rendered formula to the tap repository.
 6. Verify with:
 
    ```bash
-   brew tap oozoofrog/swiftnest https://github.com/oozoofrog/homebrew-swiftnest
+   brew tap oozoofrog/tap https://github.com/oozoofrog/homebrew-tap
    brew install swiftnest
    swiftnest --version
    swiftnest onboard --target /tmp/sample-repo --skill-agent codex --non-interactive

--- a/packaging/homebrew/render_formula.sh
+++ b/packaging/homebrew/render_formula.sh
@@ -9,7 +9,7 @@ Examples:
   ./packaging/homebrew/render_formula.sh \
     --tag v0.1.0 \
     --archive /tmp/swift-nest-v0.1.0.tar.gz \
-    --output /tmp/homebrew-swiftnest/Formula/swiftnest.rb
+    --output /tmp/homebrew-tap/Formula/swiftnest.rb
 EOF
 }
 


### PR DESCRIPTION
## Summary

- 통합 Homebrew tap(`oozoofrog/homebrew-tap`)으로 SwiftNest formula 이전
- swift-nest 리포 내 모든 `homebrew-swiftnest` 참조를 `homebrew-tap`으로 업데이트
- `oozoofrog/homebrew-tap`에는 `Formula/swiftnest.rb` (v0.1.7)가 이미 직접 커밋됨

## Changed files

- `README.md` — tap 참조 및 install 명령 업데이트
- `README_kr.md` — tap 참조 및 install 명령 업데이트
- `AGENTS.md` — Homebrew release follow-up 섹션의 tap 경로 업데이트
- `packaging/homebrew/README.md` — formula 출력 경로 및 tap 명령 업데이트
- `packaging/homebrew/render_formula.sh` — usage 예시의 출력 경로 업데이트

## Install command change

```bash
# Before
brew tap oozoofrog/swiftnest https://github.com/oozoofrog/homebrew-swiftnest

# After
brew tap oozoofrog/tap https://github.com/oozoofrog/homebrew-tap
```

## Test plan

- [x] `grep -r "homebrew-swiftnest" --include="*.md" --include="*.sh" .` → 결과 없음 확인
- [x] `ruby -c` formula 구문 검증 통과
- [ ] `brew tap oozoofrog/tap && brew install swiftnest` 동작 확인

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)